### PR TITLE
rename package to PlutoExtractors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-name = "PlutoExtracters"
+name = "PlutoExtractors"
 uuid = "25cc9095-8c7a-4c84-8905-c5de52e7766c"
 authors = ["ederag <edera@gmx.fr> and contributors"]
 version = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# PlutoExtracters
+# PlutoExtractors
 
-[![Build Status](https://github.com/ederag/PlutoExtracters.jl/actions/workflows/CI.yml/badge.svg?branch=master)](https://github.com/ederag/PlutoExtracters.jl/actions/workflows/CI.yml?query=branch%3Amaster)
+[![Build Status](https://github.com/ederag/PlutoExtractors.jl/actions/workflows/CI.yml/badge.svg?branch=master)](https://github.com/ederag/PlutoExtractors.jl/actions/workflows/CI.yml?query=branch%3Amaster)
 
 ## Feature
 
@@ -37,8 +37,8 @@ but from anywhere else (a script, the REPL, ...).
 Say in the source notebook there are three cells: `a = 1`, `b = 2a`, `c = 2b`,
 here is how to make a function that return the value `c` from any given `a`:
 ```julia
-julia> using PlutoExtracters: load_nb_with_topology, @nb_extract
-julia> source_path = pkgdir(PlutoExtracters,
+julia> using PlutoExtractors: load_nb_with_topology, @nb_extract
+julia> source_path = pkgdir(PlutoExtractors,
 	"test", "notebooks", "source_basic.jl"
 )  # to be replaced with the path of your source notebook
 julia> nb = load_nb_with_topology(source_path);

--- a/src/PlutoExtracters.jl
+++ b/src/PlutoExtracters.jl
@@ -1,8 +1,0 @@
-module PlutoExtracters
-
-include("./notebooks/extracters.jl")
-
-export @nb_extract
-export load_nb_with_topology
-
-end

--- a/src/PlutoExtractors.jl
+++ b/src/PlutoExtractors.jl
@@ -1,0 +1,8 @@
+module PlutoExtractors
+
+include("./notebooks/extractors.jl")
+
+export @nb_extract
+export load_nb_with_topology
+
+end

--- a/src/notebooks/extractors.jl
+++ b/src/notebooks/extractors.jl
@@ -90,7 +90,7 @@ function all_needed_cells(nb::Pluto.Notebook, cell; given=[])
 end
 
 # ╔═╡ c71b4e52-5d6a-4a82-b465-b755217198e6
-function nb_extracter_body(nb::Pluto.Notebook; given=[], outputs=[])
+function nb_extractor_body(nb::Pluto.Notebook; given=[], outputs=[])
 	output_cells = find_symbols_cells(nb, outputs)
 	needed_cells = mapreduce(
 		c -> all_needed_cells(nb, c; given),
@@ -119,8 +119,8 @@ function nb_extracter_body(nb::Pluto.Notebook; given=[], outputs=[])
 end
 
 # ╔═╡ ea0ba472-50a3-4ab6-a221-0b710b361fca
-function nb_extracter(nb::Pluto.Notebook; given=[], outputs=[])
-	code = nb_extracter_code(nb; given, outputs)
+function nb_extractor(nb::Pluto.Notebook; given=[], outputs=[])
+	code = nb_extractor_code(nb; given, outputs)
 	return eval(
 		Meta.parse(code)
 	)
@@ -177,8 +177,8 @@ but from anywhere else (a script, the REPL, ...).
 Say in the source notebook there are three cells: `a = 1`, `b = 2a`, `c = 2b`,
 here is how to make a function that return the value `c` from any given `a`:
 ```jldoctest
-julia> using PlutoExtracters: load_nb_with_topology, @nb_extract
-julia> source_path = pkgdir(PlutoExtracters,
+julia> using PlutoExtractors: load_nb_with_topology, @nb_extract
+julia> source_path = pkgdir(PlutoExtractors,
 	"test", "notebooks", "source_basic.jl"
 )  # to be replaced with the path of your source notebook
 julia> nb = load_nb_with_topology(source_path);
@@ -252,12 +252,12 @@ macro nb_extract(nb, template)
 	end
 	# We assign the gensym_name to the function name in the dict
 	d[:name] = gensym_name
-	# `nb_extracter_body` needs to know about the real notebook
+	# `nb_extractor_body` needs to know about the real notebook
 	# so the following can only be done at runtime.
 	# => Just prepare the expressions to be evaluated when the macro is executed.
 	return quote
 		let
-			extracted_block = nb_extracter_body(
+			extracted_block = nb_extractor_body(
 				$(esc(nb));
 				given=$given,
 				outputs=$outputs

--- a/test/notebooks/extract_from_source_basic.jl
+++ b/test/notebooks/extract_from_source_basic.jl
@@ -17,13 +17,13 @@ end
   ╠═╡ =#
 
 # ╔═╡ ca7520d3-c140-411d-b80d-c9cb03c7724d
-using PlutoExtracters
+using PlutoExtractors
 
 # ╔═╡ 780d2266-5ca3-413c-b354-6fb8c782bb30
 import PlutoTest
 
 # ╔═╡ 23e9bd17-9d56-4a4d-a76c-03095b959465
-root_dir = pkgdir(PlutoExtracters)
+root_dir = pkgdir(PlutoExtractors)
 
 # ╔═╡ 35bab28c-477c-43dd-b339-13cfdbf2f33e
 source_nb_file = joinpath(root_dir, "test", "notebooks", "source_basic.jl")

--- a/test/notebooks/extract_from_source_consts.jl
+++ b/test/notebooks/extract_from_source_consts.jl
@@ -14,13 +14,13 @@ begin
 end
 
 # ╔═╡ e9956baf-c12b-4f45-8e65-c03b9cc70d77
-using PlutoExtracters
+using PlutoExtractors
 
 # ╔═╡ 85aa7d19-b432-423c-9124-2ec8d8a1f24e
 import PlutoTest
 
 # ╔═╡ 15bb49ff-61f0-40f4-ae45-b9a709bd5c57
-root_dir = pkgdir(PlutoExtracters)
+root_dir = pkgdir(PlutoExtractors)
 
 # ╔═╡ 818ce446-5aaf-4b71-8068-bf26b86a61f9
 source_nb_file = joinpath(root_dir, "test", "notebooks", "source_consts.jl")

--- a/test/notebooks/extract_from_source_usings.jl
+++ b/test/notebooks/extract_from_source_usings.jl
@@ -14,7 +14,7 @@ begin
 end
 
 # ╔═╡ 640d5a61-0e23-4614-96d7-6d79e015eee3
-using PlutoExtracters
+using PlutoExtractors
 
 # ╔═╡ 63066171-c4e6-46e6-8e63-eb50f6c70ed1
 using LinearAlgebra: dot  # `dot` is needed for the test
@@ -23,7 +23,7 @@ using LinearAlgebra: dot  # `dot` is needed for the test
 import PlutoTest
 
 # ╔═╡ 88334e90-1486-40e2-84d5-8f49eda045fe
-root_dir = pkgdir(PlutoExtracters)
+root_dir = pkgdir(PlutoExtractors)
 
 # ╔═╡ d5a36c7c-95bf-4bd3-96d7-1b2392eeec94
 source_nb_file = joinpath(root_dir, "test", "notebooks", "source_usings.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using PlutoExtracters
+using PlutoExtractors
 using Test
 using Pluto
 
@@ -22,7 +22,7 @@ fakeclient = Pluto.ClientSession(:fake, nothing)
 server_session.connected_clients[fakeclient.id] = fakeclient
 
 
-@testset "PlutoExtracters.jl" begin
+@testset "PlutoExtractors.jl" begin
 	@testset "try" begin
 	    include("try.jl")
 	end

--- a/test/try.jl
+++ b/test/try.jl
@@ -2,11 +2,11 @@
 # where server_session is defined
 
 @testset "Try" begin
-	source_basic_path = pkgdir(PlutoExtracters, "test", "notebooks", "source_basic.jl")
+	source_basic_path = pkgdir(PlutoExtractors, "test", "notebooks", "source_basic.jl")
 
 	# "# expected" cells produce an output that the next cell should reproduce
 	dest_notebook = Pluto.Notebook([
-		Pluto.Cell("""using PlutoExtracters"""),
+		Pluto.Cell("""using PlutoExtractors"""),
 		Pluto.Cell("""nb = load_nb_with_topology("$(source_basic_path)")"""),
 		Pluto.Cell("""
 			@nb_extract(nb, 


### PR DESCRIPTION
English-speaking people consider the 'e' as a typo.

This was discussed on [zulip](https://julialang.zulipchat.com/#narrow/stream/243342-pluto.2Ejl/topic/PlutoExtracters/near/288501306).

I'll wait for your approval (in case you'd be working on it), rename the github repo, and merge if tests pass again.