### PR TITLE
Run notebook to fully resolve topology

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
 PlutoTest = "cb4044da-4d16-4ffa-a6a3-8cad7f73ebdc"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
+Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 
 [compat]
 BenchmarkTools = "1"
@@ -23,8 +24,9 @@ julia = "1.6"
 
 [extras]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Revise", "LinearAlgebra"]
+test = ["Test", "Revise", "LinearAlgebra", "Parameters"]

--- a/src/notebooks/extractors.jl
+++ b/src/notebooks/extractors.jl
@@ -102,6 +102,9 @@ end
 # ╔═╡ c71b4e52-5d6a-4a82-b465-b755217198e6
 function nb_extractor_body(nb::Pluto.Notebook; given=[], outputs=[])
 	output_cells = find_symbols_cells(nb, outputs)
+	isempty(output_cells) && error(
+		"Unable to extract any definition for $outputs"
+	)
 	needed_cells = mapreduce(
 		c -> all_needed_cells(nb, c; given),
 		union,

--- a/src/notebooks/extractors.jl
+++ b/src/notebooks/extractors.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.9
+# v0.19.18
 
 #> [frontmatter]
 #> title = ""

--- a/src/notebooks/extractors.jl
+++ b/src/notebooks/extractors.jl
@@ -34,9 +34,11 @@ See also [`@nb_extract`](@ref)
 """
 function load_nb_with_topology(path::AbstractString)
 	nb = Pluto.load_notebook_nobackup(String(path))
-	old_tp = nb.topology
-	new_tp = nb.topology = Pluto.updated_topology(old_tp, nb, nb.cells)
-	Pluto.update_dependency_cache!(nb)
+
+	# To handle macros. TODO: room for optimization
+	sub_session = Pluto.ServerSession()
+	Pluto.update_run!(sub_session, nb, nb.cells)
+
 	nb
 end
 

--- a/test/notebooks/extract_from_source_basic.jl
+++ b/test/notebooks/extract_from_source_basic.jl
@@ -151,6 +151,21 @@ PlutoTest.@test fun_5(2) == 8
 # ╔═╡ f4410aeb-b742-4732-9789-640ec466637a
 PlutoTest.@test_throws MethodError fun_5(2.0)
 
+# ╔═╡ 62989d10-0da0-41ca-8d70-f6d2d2bb5435
+md"""
+# Errors
+"""
+
+# ╔═╡ 4366181c-9516-436e-8072-31488d4722ab
+PlutoTest.@test_throws ErrorException(
+	"Unable to extract any definition for Any[:non_existing]"
+) @nb_extract(
+	nb,
+	function fun_error_1()
+		return non_existing  # :non_existing is not defined in nb
+	end
+)
+
 # ╔═╡ Cell order:
 # ╠═64f6372a-eff1-11ec-2395-31d68eda5f3a
 # ╠═0758f6c1-f7e0-4f9e-911a-c5d21f4b0d50
@@ -184,3 +199,5 @@ PlutoTest.@test_throws MethodError fun_5(2.0)
 # ╠═484fb80e-2722-42b9-bb39-6f2cade9b076
 # ╠═88a74364-04b6-4083-a584-eafcdea3e73c
 # ╠═f4410aeb-b742-4732-9789-640ec466637a
+# ╠═62989d10-0da0-41ca-8d70-f6d2d2bb5435
+# ╠═4366181c-9516-436e-8072-31488d4722ab

--- a/test/notebooks/extract_from_source_basic.jl
+++ b/test/notebooks/extract_from_source_basic.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.9
+# v0.19.18
 
 using Markdown
 using InteractiveUtils

--- a/test/notebooks/extract_from_source_consts.jl
+++ b/test/notebooks/extract_from_source_consts.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.9
+# v0.19.22
 
 using Markdown
 using InteractiveUtils
@@ -8,10 +8,13 @@ using InteractiveUtils
 import Pkg
 
 # ╔═╡ 5777e9cd-9feb-40a5-add3-bc983fe9833e
+# ╠═╡ skip_as_script = true
+#=╠═╡
 begin
 	Pkg.activate(Base.current_project())
 	using Revise  # just to be sure Revise is called first (is it necessary ?)
 end
+  ╠═╡ =#
 
 # ╔═╡ e9956baf-c12b-4f45-8e65-c03b9cc70d77
 using PlutoExtractors

--- a/test/notebooks/extract_from_source_unpack.jl
+++ b/test/notebooks/extract_from_source_unpack.jl
@@ -1,0 +1,121 @@
+### A Pluto.jl notebook ###
+# v0.19.18
+
+using Markdown
+using InteractiveUtils
+
+# ╔═╡ 51df9d39-7d35-49e1-bac3-7354882bb141
+import Pkg
+
+# ╔═╡ 67aa154f-a294-41ce-aea5-36cf5ddcf1de
+begin
+	Pkg.activate(Base.current_project())
+	using Revise  # just to be sure Revise is called first (is it necessary ?)
+end
+
+# ╔═╡ 640d5a61-0e23-4614-96d7-6d79e015eee3
+using PlutoExtractors
+
+# ╔═╡ 63066171-c4e6-46e6-8e63-eb50f6c70ed1
+using LinearAlgebra: dot  # `dot` is needed for the test
+
+# ╔═╡ 9f58ade4-c81b-45fb-a497-4f7503b94e13
+import PlutoTest
+
+# ╔═╡ 88334e90-1486-40e2-84d5-8f49eda045fe
+root_dir = pkgdir(PlutoExtractors)
+
+# ╔═╡ d5a36c7c-95bf-4bd3-96d7-1b2392eeec94
+source_nb_file = joinpath(root_dir, "test", "notebooks", "source_unpack.jl")
+
+# ╔═╡ f3ee4c34-3c96-4254-aa07-34d67efaedc3
+nb = load_nb_with_topology(source_nb_file)
+
+# ╔═╡ 8411b188-54d9-43fd-9d47-6bd6d7f5ed86
+md"""
+# Tests
+"""
+
+# ╔═╡ 53c808e9-a4bc-4fbc-b186-41532f54e7f8
+md"## Regular
+
+`a` and `c` are defined through `@unpack` in the source file
+"
+
+# ╔═╡ 21f86448-721a-4ffe-a098-1482071de585
+@nb_extract(
+	nb,
+	function fun1()
+		return a, c
+	end
+)
+
+# ╔═╡ 737782bb-ea44-41b4-b467-da42793fd616
+PlutoTest.@test fun1() == (1, 3)
+
+# ╔═╡ b8bb2593-70f3-4131-9f6c-a5ed559a80b9
+md"""
+## Workaround
+
+`k` is first defined through a dummy assignment, and then through `@unpack`,
+in the same cell.
+
+This way a `k` definition is reckognized.
+The subsequent failure occurs because `using Parameters` is not extracted yet.
+"""
+
+# ╔═╡ 525f5fcc-efd1-48ef-8aeb-9c184e54a50d
+@nb_extract(
+	nb,
+	function fun2()
+		return k
+	end
+)
+
+# ╔═╡ b8879c23-6aec-435a-a875-e30ebd1b4d5a
+fun1()
+
+# ╔═╡ 9cf1c8ea-6043-41cd-abdd-595ebf5254b2
+PlutoTest.@test fun2() == 11
+
+# ╔═╡ 58fd5a19-e13b-4ad5-aa20-d0665d42ca53
+PlutoExtractors.nb_extractor_body(nb; given=[], outputs=[:a])
+
+# ╔═╡ 75bf02ea-251e-453a-a8f5-8b235fcd7cd1
+PlutoExtractors.find_definition_cells(nb, [:a])
+
+# ╔═╡ 8b8411aa-1aec-4ffb-940d-b987cb0396ec
+unpack_cell = filter(c -> contains(c.code, "@unpack"), nb.cells) |> last
+
+# ╔═╡ e71767af-fc31-4710-9dc6-b7caa4954156
+nb.topology.nodes[unpack_cell].definitions
+
+# ╔═╡ 37faddba-2ebf-41dc-8d0d-e762257ad3d8
+nb.topology.nodes[unpack_cell].soft_definitions
+
+# ╔═╡ 008899b8-4950-4994-88e2-6165ac12321f
+nb.topology.nodes[unpack_cell].macrocalls
+
+# ╔═╡ Cell order:
+# ╠═51df9d39-7d35-49e1-bac3-7354882bb141
+# ╠═67aa154f-a294-41ce-aea5-36cf5ddcf1de
+# ╠═640d5a61-0e23-4614-96d7-6d79e015eee3
+# ╠═9f58ade4-c81b-45fb-a497-4f7503b94e13
+# ╠═63066171-c4e6-46e6-8e63-eb50f6c70ed1
+# ╠═88334e90-1486-40e2-84d5-8f49eda045fe
+# ╠═d5a36c7c-95bf-4bd3-96d7-1b2392eeec94
+# ╠═f3ee4c34-3c96-4254-aa07-34d67efaedc3
+# ╠═8411b188-54d9-43fd-9d47-6bd6d7f5ed86
+# ╠═53c808e9-a4bc-4fbc-b186-41532f54e7f8
+# ╠═21f86448-721a-4ffe-a098-1482071de585
+# ╠═737782bb-ea44-41b4-b467-da42793fd616
+# ╠═b8bb2593-70f3-4131-9f6c-a5ed559a80b9
+# ╠═525f5fcc-efd1-48ef-8aeb-9c184e54a50d
+# ╠═b8879c23-6aec-435a-a875-e30ebd1b4d5a
+# ╠═9cf1c8ea-6043-41cd-abdd-595ebf5254b2
+# ╠═58fd5a19-e13b-4ad5-aa20-d0665d42ca53
+# ╠═75bf02ea-251e-453a-a8f5-8b235fcd7cd1
+# ╠═8b8411aa-1aec-4ffb-940d-b987cb0396ec
+# ╠═e71767af-fc31-4710-9dc6-b7caa4954156
+# ╠═37faddba-2ebf-41dc-8d0d-e762257ad3d8
+# ╠═008899b8-4950-4994-88e2-6165ac12321f

--- a/test/notebooks/extract_from_source_unpack.jl
+++ b/test/notebooks/extract_from_source_unpack.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.19
+# v0.19.22
 
 using Markdown
 using InteractiveUtils
@@ -8,10 +8,13 @@ using InteractiveUtils
 import Pkg
 
 # ╔═╡ 67aa154f-a294-41ce-aea5-36cf5ddcf1de
+# ╠═╡ skip_as_script = true
+#=╠═╡
 begin
 	Pkg.activate(Base.current_project())
 	using Revise  # just to be sure Revise is called first (is it necessary ?)
 end
+  ╠═╡ =#
 
 # ╔═╡ ef466826-81b7-4f9d-a0e8-f48f0dc63d2f
 using Parameters  # until #11 is fixed

--- a/test/notebooks/extract_from_source_unpack.jl
+++ b/test/notebooks/extract_from_source_unpack.jl
@@ -56,6 +56,21 @@ md"## Regular
 # ╔═╡ 737782bb-ea44-41b4-b467-da42793fd616
 PlutoTest.@test fun1() == (1, 3)
 
+# ╔═╡ d3341aee-be88-4f4c-a25b-7f2342a98591
+md"""
+## Debug
+"""
+
+# ╔═╡ 198d4900-9ae1-456f-b1cf-3c26a2d8249a
+unpack_ac_cell = filter(c -> contains(c.code, "@unpack a, c ="), nb.cells) |> only
+
+# ╔═╡ 1f19f8ec-46e5-48d7-a557-15db25bc12ff
+unpack_ac_node = nb.topology.nodes[unpack_ac_cell]
+
+# ╔═╡ d011ab60-c791-43e4-babc-675be0a8b709
+# true (but should not be part of the test suite)
+unpack_ac_node.definitions == Set([:a, :c])
+
 # ╔═╡ b8bb2593-70f3-4131-9f6c-a5ed559a80b9
 md"""
 ## Workaround
@@ -113,6 +128,10 @@ nb.topology.nodes[unpack_cell].macrocalls
 # ╠═53c808e9-a4bc-4fbc-b186-41532f54e7f8
 # ╠═21f86448-721a-4ffe-a098-1482071de585
 # ╠═737782bb-ea44-41b4-b467-da42793fd616
+# ╠═d3341aee-be88-4f4c-a25b-7f2342a98591
+# ╠═198d4900-9ae1-456f-b1cf-3c26a2d8249a
+# ╠═1f19f8ec-46e5-48d7-a557-15db25bc12ff
+# ╠═d011ab60-c791-43e4-babc-675be0a8b709
 # ╠═b8bb2593-70f3-4131-9f6c-a5ed559a80b9
 # ╠═525f5fcc-efd1-48ef-8aeb-9c184e54a50d
 # ╠═b8879c23-6aec-435a-a875-e30ebd1b4d5a

--- a/test/notebooks/extract_from_source_unpack.jl
+++ b/test/notebooks/extract_from_source_unpack.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.18
+# v0.19.19
 
 using Markdown
 using InteractiveUtils
@@ -71,49 +71,6 @@ unpack_ac_node = nb.topology.nodes[unpack_ac_cell]
 # true (but should not be part of the test suite)
 unpack_ac_node.definitions == Set([:a, :c])
 
-# ╔═╡ b8bb2593-70f3-4131-9f6c-a5ed559a80b9
-md"""
-## Workaround
-
-`k` is first defined through a dummy assignment, and then through `@unpack`,
-in the same cell.
-
-This way a `k` definition is reckognized.
-The subsequent failure occurs because `using Parameters` is not extracted yet.
-"""
-
-# ╔═╡ 525f5fcc-efd1-48ef-8aeb-9c184e54a50d
-@nb_extract(
-	nb,
-	function fun2()
-		return k
-	end
-)
-
-# ╔═╡ b8879c23-6aec-435a-a875-e30ebd1b4d5a
-fun1()
-
-# ╔═╡ 9cf1c8ea-6043-41cd-abdd-595ebf5254b2
-PlutoTest.@test fun2() == 11
-
-# ╔═╡ 58fd5a19-e13b-4ad5-aa20-d0665d42ca53
-PlutoExtractors.nb_extractor_body(nb; given=[], outputs=[:a])
-
-# ╔═╡ 75bf02ea-251e-453a-a8f5-8b235fcd7cd1
-PlutoExtractors.find_definition_cells(nb, [:a])
-
-# ╔═╡ 8b8411aa-1aec-4ffb-940d-b987cb0396ec
-unpack_cell = filter(c -> contains(c.code, "@unpack"), nb.cells) |> last
-
-# ╔═╡ e71767af-fc31-4710-9dc6-b7caa4954156
-nb.topology.nodes[unpack_cell].definitions
-
-# ╔═╡ 37faddba-2ebf-41dc-8d0d-e762257ad3d8
-nb.topology.nodes[unpack_cell].soft_definitions
-
-# ╔═╡ 008899b8-4950-4994-88e2-6165ac12321f
-nb.topology.nodes[unpack_cell].macrocalls
-
 # ╔═╡ Cell order:
 # ╠═51df9d39-7d35-49e1-bac3-7354882bb141
 # ╠═67aa154f-a294-41ce-aea5-36cf5ddcf1de
@@ -132,13 +89,3 @@ nb.topology.nodes[unpack_cell].macrocalls
 # ╠═198d4900-9ae1-456f-b1cf-3c26a2d8249a
 # ╠═1f19f8ec-46e5-48d7-a557-15db25bc12ff
 # ╠═d011ab60-c791-43e4-babc-675be0a8b709
-# ╠═b8bb2593-70f3-4131-9f6c-a5ed559a80b9
-# ╠═525f5fcc-efd1-48ef-8aeb-9c184e54a50d
-# ╠═b8879c23-6aec-435a-a875-e30ebd1b4d5a
-# ╠═9cf1c8ea-6043-41cd-abdd-595ebf5254b2
-# ╠═58fd5a19-e13b-4ad5-aa20-d0665d42ca53
-# ╠═75bf02ea-251e-453a-a8f5-8b235fcd7cd1
-# ╠═8b8411aa-1aec-4ffb-940d-b987cb0396ec
-# ╠═e71767af-fc31-4710-9dc6-b7caa4954156
-# ╠═37faddba-2ebf-41dc-8d0d-e762257ad3d8
-# ╠═008899b8-4950-4994-88e2-6165ac12321f

--- a/test/notebooks/extract_from_source_unpack.jl
+++ b/test/notebooks/extract_from_source_unpack.jl
@@ -13,6 +13,9 @@ begin
 	using Revise  # just to be sure Revise is called first (is it necessary ?)
 end
 
+# ╔═╡ ef466826-81b7-4f9d-a0e8-f48f0dc63d2f
+using Parameters  # until #11 is fixed
+
 # ╔═╡ 640d5a61-0e23-4614-96d7-6d79e015eee3
 using PlutoExtractors
 
@@ -99,6 +102,7 @@ nb.topology.nodes[unpack_cell].macrocalls
 # ╔═╡ Cell order:
 # ╠═51df9d39-7d35-49e1-bac3-7354882bb141
 # ╠═67aa154f-a294-41ce-aea5-36cf5ddcf1de
+# ╠═ef466826-81b7-4f9d-a0e8-f48f0dc63d2f
 # ╠═640d5a61-0e23-4614-96d7-6d79e015eee3
 # ╠═9f58ade4-c81b-45fb-a497-4f7503b94e13
 # ╠═63066171-c4e6-46e6-8e63-eb50f6c70ed1

--- a/test/notebooks/extract_from_source_usings.jl
+++ b/test/notebooks/extract_from_source_usings.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.9
+# v0.19.22
 
 using Markdown
 using InteractiveUtils
@@ -8,10 +8,13 @@ using InteractiveUtils
 import Pkg
 
 # ╔═╡ 67aa154f-a294-41ce-aea5-36cf5ddcf1de
+# ╠═╡ skip_as_script = true
+#=╠═╡
 begin
 	Pkg.activate(Base.current_project())
 	using Revise  # just to be sure Revise is called first (is it necessary ?)
 end
+  ╠═╡ =#
 
 # ╔═╡ 640d5a61-0e23-4614-96d7-6d79e015eee3
 using PlutoExtractors

--- a/test/notebooks/source_basic.jl
+++ b/test/notebooks/source_basic.jl
@@ -1,8 +1,17 @@
 ### A Pluto.jl notebook ###
-# v0.19.9
+# v0.19.22
 
 using Markdown
 using InteractiveUtils
+
+# ╔═╡ 588ca7b5-0be6-42b1-95ef-850754832ad8
+import Pkg
+
+# ╔═╡ d54f6eae-833b-4337-bff7-c0e851b4b5af
+# ╠═╡ skip_as_script = true
+#=╠═╡
+Pkg.activate(Base.current_project())
+  ╠═╡ =#
 
 # ╔═╡ 5460ab14-ea6f-11ec-083c-339d0912f969
 a = 1
@@ -13,24 +22,9 @@ b = 2a
 # ╔═╡ 73585a4f-c88d-4221-bae9-dbd7e1f927e5
 c = 2b
 
-# ╔═╡ 00000000-0000-0000-0000-000000000001
-PLUTO_PROJECT_TOML_CONTENTS = """
-[deps]
-"""
-
-# ╔═╡ 00000000-0000-0000-0000-000000000002
-PLUTO_MANIFEST_TOML_CONTENTS = """
-# This file is machine-generated - editing it directly is not advised
-
-julia_version = "1.7.3"
-manifest_format = "2.0"
-
-[deps]
-"""
-
 # ╔═╡ Cell order:
+# ╠═588ca7b5-0be6-42b1-95ef-850754832ad8
+# ╠═d54f6eae-833b-4337-bff7-c0e851b4b5af
 # ╠═5460ab14-ea6f-11ec-083c-339d0912f969
 # ╠═1b45d930-ffb8-48b1-974e-29e3257e0633
 # ╠═73585a4f-c88d-4221-bae9-dbd7e1f927e5
-# ╟─00000000-0000-0000-0000-000000000001
-# ╟─00000000-0000-0000-0000-000000000002

--- a/test/notebooks/source_consts.jl
+++ b/test/notebooks/source_consts.jl
@@ -1,8 +1,18 @@
 ### A Pluto.jl notebook ###
-# v0.19.9
+# v0.19.22
 
 using Markdown
 using InteractiveUtils
+
+# ╔═╡ 41deb293-03a2-486a-afe5-b5d562c1e82e
+import Pkg
+
+# ╔═╡ 0c1494f6-361c-4918-983f-bf0b0e4fc259
+# ╠═╡ skip_as_script = true
+#=╠═╡
+# avoid julia version clashes during testing
+Pkg.activate(Base.current_project())
+  ╠═╡ =#
 
 # ╔═╡ ddaac278-e77d-4347-bff0-8ae4f8bc1cb8
 const a = 1
@@ -13,24 +23,9 @@ const b = 2a
 # ╔═╡ c6cf79c4-8829-4f87-89ff-3d52582f4af2
 const c = 2b
 
-# ╔═╡ 00000000-0000-0000-0000-000000000001
-PLUTO_PROJECT_TOML_CONTENTS = """
-[deps]
-"""
-
-# ╔═╡ 00000000-0000-0000-0000-000000000002
-PLUTO_MANIFEST_TOML_CONTENTS = """
-# This file is machine-generated - editing it directly is not advised
-
-julia_version = "1.7.3"
-manifest_format = "2.0"
-
-[deps]
-"""
-
 # ╔═╡ Cell order:
+# ╠═41deb293-03a2-486a-afe5-b5d562c1e82e
+# ╠═0c1494f6-361c-4918-983f-bf0b0e4fc259
 # ╠═ddaac278-e77d-4347-bff0-8ae4f8bc1cb8
 # ╠═c8e6ea08-4018-4ab4-bc1a-1126e5fa4e28
 # ╠═c6cf79c4-8829-4f87-89ff-3d52582f4af2
-# ╟─00000000-0000-0000-0000-000000000001
-# ╟─00000000-0000-0000-0000-000000000002

--- a/test/notebooks/source_types.jl
+++ b/test/notebooks/source_types.jl
@@ -1,8 +1,15 @@
 ### A Pluto.jl notebook ###
-# v0.19.9
+# v0.19.22
 
 using Markdown
 using InteractiveUtils
+
+# ╔═╡ a9d0dc94-7c75-431a-b25d-7d89d2a3a9be
+import Pkg
+
+# ╔═╡ 89e763c1-1a08-4b40-9fbf-b03b400ead5d
+# avoid julia version clashes during testing
+Pkg.activate(Base.current_project())
 
 # ╔═╡ 8c9967cf-9e6d-47c9-b7fd-558c78246562
 abstract type AbstractPoint end
@@ -19,25 +26,10 @@ a = Point(1, 2)
 # ╔═╡ c8e6ea08-4018-4ab4-bc1a-1126e5fa4e28
 b = 2a.x
 
-# ╔═╡ 00000000-0000-0000-0000-000000000001
-PLUTO_PROJECT_TOML_CONTENTS = """
-[deps]
-"""
-
-# ╔═╡ 00000000-0000-0000-0000-000000000002
-PLUTO_MANIFEST_TOML_CONTENTS = """
-# This file is machine-generated - editing it directly is not advised
-
-julia_version = "1.7.3"
-manifest_format = "2.0"
-
-[deps]
-"""
-
 # ╔═╡ Cell order:
+# ╠═a9d0dc94-7c75-431a-b25d-7d89d2a3a9be
+# ╠═89e763c1-1a08-4b40-9fbf-b03b400ead5d
 # ╠═8c9967cf-9e6d-47c9-b7fd-558c78246562
 # ╠═51d30d68-ec90-4df7-9542-88066d689e80
 # ╠═ddaac278-e77d-4347-bff0-8ae4f8bc1cb8
 # ╠═c8e6ea08-4018-4ab4-bc1a-1126e5fa4e28
-# ╟─00000000-0000-0000-0000-000000000001
-# ╟─00000000-0000-0000-0000-000000000002

--- a/test/notebooks/source_unpack.jl
+++ b/test/notebooks/source_unpack.jl
@@ -1,8 +1,15 @@
 ### A Pluto.jl notebook ###
-# v0.19.19
+# v0.19.22
 
 using Markdown
 using InteractiveUtils
+
+# ╔═╡ 0493f36f-42d4-483a-b891-4f1f3002d977
+import Pkg
+
+# ╔═╡ f58794b8-d83c-43a6-afbd-e887c0306182
+# avoid julia version clashes during testing
+Pkg.activate(Base.current_project())
 
 # ╔═╡ 7697635f-d048-4e0e-aeed-0229164026de
 using Parameters: @unpack
@@ -26,89 +33,9 @@ PlutoTest.@test c == 3
 # just to check regular extracts
 d = 4
 
-# ╔═╡ 00000000-0000-0000-0000-000000000001
-PLUTO_PROJECT_TOML_CONTENTS = """
-[deps]
-Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
-PlutoTest = "cb4044da-4d16-4ffa-a6a3-8cad7f73ebdc"
-
-[compat]
-Parameters = "~0.12.3"
-PlutoTest = "~0.2.2"
-"""
-
-# ╔═╡ 00000000-0000-0000-0000-000000000002
-PLUTO_MANIFEST_TOML_CONTENTS = """
-# This file is machine-generated - editing it directly is not advised
-
-julia_version = "1.8.3"
-manifest_format = "2.0"
-project_hash = "8ac9c9dcc103e2f3349aeb32533abe158f664549"
-
-[[deps.Base64]]
-uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
-
-[[deps.HypertextLiteral]]
-deps = ["Tricks"]
-git-tree-sha1 = "c47c5fa4c5308f27ccaac35504858d8914e102f9"
-uuid = "ac1192a8-f4b3-4bfe-ba22-af5b92cd3ab2"
-version = "0.9.4"
-
-[[deps.InteractiveUtils]]
-deps = ["Markdown"]
-uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
-
-[[deps.Logging]]
-uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
-
-[[deps.Markdown]]
-deps = ["Base64"]
-uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
-
-[[deps.OrderedCollections]]
-git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
-uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.4.1"
-
-[[deps.Parameters]]
-deps = ["OrderedCollections", "UnPack"]
-git-tree-sha1 = "34c0e9ad262e5f7fc75b10a9952ca7692cfc5fbe"
-uuid = "d96e819e-fc66-5662-9728-84c9c7592b0a"
-version = "0.12.3"
-
-[[deps.PlutoTest]]
-deps = ["HypertextLiteral", "InteractiveUtils", "Markdown", "Test"]
-git-tree-sha1 = "17aa9b81106e661cffa1c4c36c17ee1c50a86eda"
-uuid = "cb4044da-4d16-4ffa-a6a3-8cad7f73ebdc"
-version = "0.2.2"
-
-[[deps.Random]]
-deps = ["SHA", "Serialization"]
-uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-
-[[deps.SHA]]
-uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
-version = "0.7.0"
-
-[[deps.Serialization]]
-uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
-
-[[deps.Test]]
-deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
-uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[[deps.Tricks]]
-git-tree-sha1 = "6bac775f2d42a611cdfcd1fb217ee719630c4175"
-uuid = "410a4b4d-49e4-4fbc-ab6d-cb71b17b3775"
-version = "0.1.6"
-
-[[deps.UnPack]]
-git-tree-sha1 = "387c1f73762231e86e0c9c5443ce3b4a0a9a0c2b"
-uuid = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
-version = "1.0.2"
-"""
-
 # ╔═╡ Cell order:
+# ╠═0493f36f-42d4-483a-b891-4f1f3002d977
+# ╠═f58794b8-d83c-43a6-afbd-e887c0306182
 # ╠═7697635f-d048-4e0e-aeed-0229164026de
 # ╠═c2ecf80f-11cb-4228-b7fd-7db4643c1eb5
 # ╠═5460ab14-ea6f-11ec-083c-339d0912f969
@@ -116,5 +43,3 @@ version = "1.0.2"
 # ╠═7bfed1e8-054e-475e-92b6-f926bf5c2855
 # ╠═d424a685-7296-419f-8b18-7b6170d4ee36
 # ╠═195bf3b0-67cd-4d9c-9159-5acea798fb59
-# ╟─00000000-0000-0000-0000-000000000001
-# ╟─00000000-0000-0000-0000-000000000002

--- a/test/notebooks/source_unpack.jl
+++ b/test/notebooks/source_unpack.jl
@@ -1,0 +1,131 @@
+### A Pluto.jl notebook ###
+# v0.19.18
+
+using Markdown
+using InteractiveUtils
+
+# ╔═╡ 7697635f-d048-4e0e-aeed-0229164026de
+using Parameters: @unpack
+
+# ╔═╡ c2ecf80f-11cb-4228-b7fd-7db4643c1eb5
+using PlutoTest
+
+# ╔═╡ 5460ab14-ea6f-11ec-083c-339d0912f969
+@unpack a, c = (; a = 1, b = 2, c = 3)
+
+# ╔═╡ 028686a2-bf16-48ce-bdae-eea640322d97
+PlutoTest.@test a == 1
+
+# ╔═╡ 7bfed1e8-054e-475e-92b6-f926bf5c2855
+PlutoTest.@test !@isdefined b
+
+# ╔═╡ d424a685-7296-419f-8b18-7b6170d4ee36
+PlutoTest.@test c == 3
+
+# ╔═╡ 195bf3b0-67cd-4d9c-9159-5acea798fb59
+# just to check regular extracts
+d = 4
+
+# ╔═╡ 9576878d-46f4-421c-a2e3-b5a109d22f3f
+begin
+k = 2
+@unpack k = (; k = 11)
+end
+
+# ╔═╡ b40c085d-0bd5-4b02-bedb-a694de5d03b6
+k
+
+# ╔═╡ 00000000-0000-0000-0000-000000000001
+PLUTO_PROJECT_TOML_CONTENTS = """
+[deps]
+Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
+PlutoTest = "cb4044da-4d16-4ffa-a6a3-8cad7f73ebdc"
+
+[compat]
+Parameters = "~0.12.3"
+PlutoTest = "~0.2.2"
+"""
+
+# ╔═╡ 00000000-0000-0000-0000-000000000002
+PLUTO_MANIFEST_TOML_CONTENTS = """
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.8.3"
+manifest_format = "2.0"
+project_hash = "ee5e6ec149c940eaee661e2612ca47f2c3997a56"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[deps.HypertextLiteral]]
+deps = ["Tricks"]
+git-tree-sha1 = "c47c5fa4c5308f27ccaac35504858d8914e102f9"
+uuid = "ac1192a8-f4b3-4bfe-ba22-af5b92cd3ab2"
+version = "0.9.4"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[deps.Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[deps.OrderedCollections]]
+git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.4.1"
+
+[[deps.Parameters]]
+deps = ["OrderedCollections", "UnPack"]
+git-tree-sha1 = "34c0e9ad262e5f7fc75b10a9952ca7692cfc5fbe"
+uuid = "d96e819e-fc66-5662-9728-84c9c7592b0a"
+version = "0.12.3"
+
+[[deps.PlutoTest]]
+deps = ["HypertextLiteral", "InteractiveUtils", "Markdown", "Test"]
+git-tree-sha1 = "17aa9b81106e661cffa1c4c36c17ee1c50a86eda"
+uuid = "cb4044da-4d16-4ffa-a6a3-8cad7f73ebdc"
+version = "0.2.2"
+
+[[deps.Random]]
+deps = ["SHA", "Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[deps.Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[deps.Tricks]]
+git-tree-sha1 = "6bac775f2d42a611cdfcd1fb217ee719630c4175"
+uuid = "410a4b4d-49e4-4fbc-ab6d-cb71b17b3775"
+version = "0.1.6"
+
+[[deps.UnPack]]
+git-tree-sha1 = "387c1f73762231e86e0c9c5443ce3b4a0a9a0c2b"
+uuid = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
+version = "1.0.2"
+"""
+
+# ╔═╡ Cell order:
+# ╠═7697635f-d048-4e0e-aeed-0229164026de
+# ╠═c2ecf80f-11cb-4228-b7fd-7db4643c1eb5
+# ╠═5460ab14-ea6f-11ec-083c-339d0912f969
+# ╠═028686a2-bf16-48ce-bdae-eea640322d97
+# ╠═7bfed1e8-054e-475e-92b6-f926bf5c2855
+# ╠═d424a685-7296-419f-8b18-7b6170d4ee36
+# ╠═195bf3b0-67cd-4d9c-9159-5acea798fb59
+# ╠═9576878d-46f4-421c-a2e3-b5a109d22f3f
+# ╠═b40c085d-0bd5-4b02-bedb-a694de5d03b6
+# ╟─00000000-0000-0000-0000-000000000001
+# ╟─00000000-0000-0000-0000-000000000002

--- a/test/notebooks/source_unpack.jl
+++ b/test/notebooks/source_unpack.jl
@@ -26,15 +26,6 @@ PlutoTest.@test c == 3
 # just to check regular extracts
 d = 4
 
-# ╔═╡ 9576878d-46f4-421c-a2e3-b5a109d22f3f
-begin
-k = 2
-@unpack k = (; k = 11)
-end
-
-# ╔═╡ b40c085d-0bd5-4b02-bedb-a694de5d03b6
-k
-
 # ╔═╡ 00000000-0000-0000-0000-000000000001
 PLUTO_PROJECT_TOML_CONTENTS = """
 [deps]
@@ -125,7 +116,5 @@ version = "1.0.2"
 # ╠═7bfed1e8-054e-475e-92b6-f926bf5c2855
 # ╠═d424a685-7296-419f-8b18-7b6170d4ee36
 # ╠═195bf3b0-67cd-4d9c-9159-5acea798fb59
-# ╠═9576878d-46f4-421c-a2e3-b5a109d22f3f
-# ╠═b40c085d-0bd5-4b02-bedb-a694de5d03b6
 # ╟─00000000-0000-0000-0000-000000000001
 # ╟─00000000-0000-0000-0000-000000000002

--- a/test/notebooks/source_unpack.jl
+++ b/test/notebooks/source_unpack.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.18
+# v0.19.19
 
 using Markdown
 using InteractiveUtils
@@ -52,7 +52,7 @@ PLUTO_MANIFEST_TOML_CONTENTS = """
 
 julia_version = "1.8.3"
 manifest_format = "2.0"
-project_hash = "ee5e6ec149c940eaee661e2612ca47f2c3997a56"
+project_hash = "8ac9c9dcc103e2f3349aeb32533abe158f664549"
 
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/test/notebooks/source_usings.jl
+++ b/test/notebooks/source_usings.jl
@@ -1,8 +1,15 @@
 ### A Pluto.jl notebook ###
-# v0.19.9
+# v0.19.22
 
 using Markdown
 using InteractiveUtils
+
+# ╔═╡ 52a54f2e-33f7-45f0-b251-59c476c17994
+import Pkg
+
+# ╔═╡ a1be466e-5d31-4024-8c05-6afd5ede7840
+# avoid julia version clashes during testing
+Pkg.activate(Base.current_project())
 
 # ╔═╡ d76267bc-917e-42a0-8576-33a0a84ad8e3
 using LinearAlgebra:dot
@@ -22,48 +29,12 @@ d_fun(x, y) = dot(x, y)
 # ╔═╡ f5a959b0-372f-400c-ba67-31460ceb6447
 d_indirect = d_fun(v1, v2)
 
-# ╔═╡ 00000000-0000-0000-0000-000000000001
-PLUTO_PROJECT_TOML_CONTENTS = """
-[deps]
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-"""
-
-# ╔═╡ 00000000-0000-0000-0000-000000000002
-PLUTO_MANIFEST_TOML_CONTENTS = """
-# This file is machine-generated - editing it directly is not advised
-
-julia_version = "1.7.3"
-manifest_format = "2.0"
-
-[[deps.Artifacts]]
-uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
-
-[[deps.CompilerSupportLibraries_jll]]
-deps = ["Artifacts", "Libdl"]
-uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-
-[[deps.Libdl]]
-uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
-
-[[deps.LinearAlgebra]]
-deps = ["Libdl", "libblastrampoline_jll"]
-uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-
-[[deps.OpenBLAS_jll]]
-deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
-uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
-
-[[deps.libblastrampoline_jll]]
-deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
-uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
-"""
-
 # ╔═╡ Cell order:
+# ╠═52a54f2e-33f7-45f0-b251-59c476c17994
+# ╠═a1be466e-5d31-4024-8c05-6afd5ede7840
 # ╠═d76267bc-917e-42a0-8576-33a0a84ad8e3
 # ╠═56bc6498-f5f2-11ec-0723-e94eb89c7289
 # ╠═b90ebfc8-bd7e-412a-90fc-8e2e9ecd7860
 # ╠═98b0c017-9e5f-40b7-873a-a1067cb66031
 # ╠═bb19b3d0-ad7d-4220-a117-fd6f60b0f2bc
 # ╠═f5a959b0-372f-400c-ba67-31460ceb6447
-# ╟─00000000-0000-0000-0000-000000000001
-# ╟─00000000-0000-0000-0000-000000000002

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,4 +42,8 @@ server_session.connected_clients[fakeclient.id] = fakeclient
 	@testset "Extract from source_types.jl" begin
 		include("notebooks/extract_from_source_types.jl")
 	end
+	
+	@testset "Extract from source_unpack.jl" begin
+		include("notebooks/extract_from_source_unpack.jl")
+	end
 end


### PR DESCRIPTION
As [discussed](https://julialang.zulipchat.com/#narrow/stream/243342-pluto.2Ejl/topic/How.20does.20Pluto.20identify.20definitions.20made.20inside.20a.20macro.20.3F) on zulip, macros such as `@unpack` from `Parameters.jl` need to be executed,
in order for the definitions to be known to the extractor.
Thanks a lot to @Pangoraw for the help !

Changes to
`source_basic.jl`
`source_consts.jl`
`source_types.jl`
`source_usings.jl`
`extract_from_source_basic.jl`
`extract_from_source_consts.jl`
`extract_from_source_usings.jl`
were done to fix CI.

The relevant ones are
[extractors.jl](https://github.com/ederag/PlutoExtractors.jl/pull/12/files#diff-4f2ff6142263d17dec8448c83fedd145c485c2a89d74b86dc56b23a0fcd06630)
[source_unpack.jl](https://github.com/ederag/PlutoExtractors.jl/pull/12/files#diff-728cb374b5b1774c438989246979ea246427b83b807a650e1f3e14a9a0dfcd83)
[extract_from_source_unpack.jl](https://github.com/ederag/PlutoExtractors.jl/pull/12/files#diff-833bcc97ed2464fc0e2e23b1b82692b4aeec44b01ed7f98ad0047ed7e112267f)
[runtests.jl](https://github.com/ederag/PlutoExtractors.jl/pull/12/files#diff-3b9314a6f9f2d7eec1d0ef69fa76cfabafdbe6d0df923768f9ec32f27a249c63)