### PR TITLE
No run

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1'
+          - '1.11'
           - '1.10'
           - 'nightly'
         os:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,6 @@ jobs:
         version:
           - '1.11'
           - '1.10'
-          - 'nightly'
         os:
           - ubuntu-latest
         arch:

--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
 PlutoDependencyExplorer = "72656b73-756c-7461-726b-72656b6b696b"
 PlutoTest = "cb4044da-4d16-4ffa-a6a3-8cad7f73ebdc"
+PlutoUI = "7f904dfe-b85e-4ff6-b463-dae2292396a8"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoExtractors"
 uuid = "25cc9095-8c7a-4c84-8905-c5de52e7766c"
 authors = ["ederag <edera@gmx.fr> and contributors"]
-version = "0.1.2"
+version = "0.2.0"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/README.md
+++ b/README.md
@@ -4,27 +4,24 @@
 
 ## Feature
 
-Create a function out of a `Pluto` notebook, based on a template.
+    @nb_extract(utp, template)
 
-The notebook `nb` must be a `Pluto.Notebook`,
-with up-to-date topology and dependency cache
-(for instance from [`load_nb_with_topology`](@ref)).
+Create a function out of a `Pluto` notebook updated topology,
+based on a template.
+
+The notebook updated topology `utp` is obtained
+from [`load_updated_topology`](@ref).
+This is a shallow first pass that will help determine the required packages.
 
 The signature of the returned function is exactly the one of the `template`.
-The argument names must match symbols defined in the notebook.
-The arguments values will be used instead of the source notebook ones
-in the evaluation.
+The arguments take precedence over the values defined in the notebook.
 
-The return value of this function is found in the `template` body.
-This body must consist of a single `return` statement.
-The return value can be a single variable (e.g. ` return c`),
-a tuple (e.g. `return (b, c)`), or a named tuple (e.g. `return (; b = b, whatever = c)`).
+A second pass performed on `utp` and the template are then analyzed
+to find the cells that are necessary to evaluate the template body
+(the cells that define `b` and `c` in the example below).
 
-The notebook `nb` is then analyzed to find the cells that are necessary
-to evaluate the return value
-(the cells that define `a` and `b` in the last examples).
-
-Those cells code is used as the core of the function body.
+Those cells code is prepended to the template body,
+to complete the function body.
 
 The result of the macro is this fleshed-out function,
 just as if it had been typed by hand.
@@ -33,17 +30,17 @@ Preliminary benchmarks show no overhead.
 Remark: `@nb_extract` can be used not only from a running Pluto notebook,
 but from anywhere else (a script, the REPL, ...).
 
-### Example
+# Example
 Say in the source notebook there are three cells: `a = 1`, `b = 2a`, `c = 2b`,
 here is how to make a function that return the value `c` from any given `a`:
-```julia
-julia> using PlutoExtractors: load_nb_with_topology, @nb_extract
+```jldoctest
+julia> using PlutoExtractors: load_updated_topology, @nb_extract
 julia> source_path = pkgdir(PlutoExtractors,
 	"test", "notebooks", "source_basic.jl"
 )  # to be replaced with the path of your source notebook
-julia> nb = load_nb_with_topology(source_path);
+julia> utp = load_updated_topology(source_path);
 julia> @nb_extract(
-	nb,
+	utp,
 	function fun(a)
 		return c
 	end

--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ julia> fun(2)
 
 More examples can be found in the test/notebooks/extract_from_*.jl Pluto notebooks.
 
+# About packages management
+
+The destination notebook packages are always used.
+
+So the best experience should be expected with running notebooks within the [“shared environment”](https://plutojl.org/en/docs/packages-advanced/) pattern,
+e.g. with `Pkg.activate(Base.current_project())`.
+This ensures that both source and destination share exactly the same packages versions.
+
+In principle `@nb_extract` may be used with the standard Pluto package system, but then
+1) The necessary `using` statements _must_ be copied manually to the destination notebook
+   (otherwise they would be missing from the notebook project)
+2) Something that used to work in the source _might_ fail in the destination just because packages versions differ.
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -54,9 +54,14 @@ More examples can be found in the test/notebooks/extract_from_*.jl Pluto noteboo
 
 ## Status
 
-This is early alpha stage, for the adventurous, and for early feedback.
-Work is under way to make it more robust.
+This package is in alpha stage.
+It works well here, but no doubt bugs will come up when used by others,
+please file issues !
 
-Note: the heavy work is done by
-[MacroTools.jl](https://github.com/FluxML/MacroTools.jl)
-and [Pluto.jl](https://github.com/fonsp/Pluto.jl) internals.
+## Acknowledgments
+
+Most of the work is done by
+[Pluto.jl](https://github.com/fonsp/Pluto.jl) for the notebook loading,
+as well as [ExpressionExplorer.jl](https://github.com/JuliaPluto/ExpressionExplorer.jl),
+[PlutoDependencyExplorer.jl](https://github.com/JuliaPluto/PlutoDependencyExplorer.jl)
+and [MacroTools.jl](https://github.com/FluxML/MacroTools.jl) for the analysis.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ but from anywhere else (a script, the REPL, ...).
 Say in the source notebook there are three cells: `a = 1`, `b = 2a`, `c = 2b`,
 here is how to make a function that return the value `c` from any given `a`:
 ```jldoctest
-julia> using PlutoExtractors: load_updated_topology, @nb_extract
+julia> using PlutoExtractors
 julia> source_path = pkgdir(PlutoExtractors,
 	"test", "notebooks", "source_basic.jl"
 )  # to be replaced with the path of your source notebook

--- a/src/PlutoExtractors.jl
+++ b/src/PlutoExtractors.jl
@@ -3,6 +3,7 @@ module PlutoExtractors
 include("./notebooks/extractors.jl")
 
 export @nb_extract
-export load_nb_with_topology
+export load_nb_with_topology  # deprecated in favor of load_updated_topology
+export load_updated_topology
 
 end

--- a/src/notebooks/extractors.jl
+++ b/src/notebooks/extractors.jl
@@ -434,6 +434,16 @@ function nb_extractor_body(utp, template_dict::Dict, given_symbols)
 	return types_expr, fun_expr
 end
 
+# ╔═╡ 20548484-991e-4b15-b6c5-8ea6b0bf69cb
+"""
+    rm_all_lines(ex)
+
+Return the expression ex expurged from all LineNumberNodes.
+
+Current limitation: does not propagate into `quote` ?
+"""
+rm_all_lines(ex) = MacroTools.prewalk(MacroTools.rmlines, ex)
+
 # ╔═╡ Cell order:
 # ╠═3e3102e5-9bbd-4592-a749-821ee5e42c7c
 # ╠═b96bc4ca-f8bf-45a4-bd71-cd30b94d0330
@@ -458,3 +468,4 @@ end
 # ╠═63c26add-ac5a-4a2c-9779-bd6c9710fe1a
 # ╠═e4ecb782-85af-4e66-a7af-72eca79bd191
 # ╠═da3fb260-a858-457f-8430-c6a124d1d1e5
+# ╠═20548484-991e-4b15-b6c5-8ea6b0bf69cb

--- a/src/notebooks/extractors.jl
+++ b/src/notebooks/extractors.jl
@@ -49,10 +49,17 @@ end
 
 # ╔═╡ 7e8a7524-1ae6-439d-98c6-5b2390014096
 """
-    load_updated_topology(path)
+    load_updated_topology(
+        path;
+        get_code_str = c -> c.code,
+        get_code_expr = c -> Meta.parse(c.code)
+    )
 
 Return the topology of a `Pluto` notebook found at `path`,
 with references and definitions filled.
+`get_code_str` and `get_code_expr` are passed to
+[`PlutoDependencyExplorer.updated_topology`](@ref);
+see that function doc for more details.
 
 See also [`@nb_extract`](@ref)
 """
@@ -90,6 +97,189 @@ function template_analysis(template::Expr)
 	node = EE.compute_reactive_node(template_body)
 	needed_symbols = filter(∉(given_symbols), node.references)
 	dict, given_symbols, needed_symbols
+end
+
+# ╔═╡ ba256080-73fb-4de4-be72-101318c82029
+strip_types(x::Symbol) = x
+
+# ╔═╡ feadac3a-859c-4915-bfc6-8fa607d6b606
+# This function is used to be able to strip types from the extracted arguments to forward the function call to the gensymed one
+# We want to do something like `fun(a::Something) = MODULE.#xxx#fun(a)`
+function strip_types(x::Expr)::Symbol
+	if Meta.isexpr(x, [:(::), :kw])
+		return strip_types(x.args[1]) # We recursively call strip_types till we reach the symbol or we error
+	else
+		error("This function should only receive either symbols or Expr of the type `x::Something`, `x=something` or `x::Something=something`. Instead `$x` was given as input")
+	end
+end
+
+# ╔═╡ 5c15516e-e3e1-401b-97b5-f4ce60e3a234
+function fun_wrapper(template_dict, module_sym::Symbol)
+	# Wrapper to be evaluated in the caller scope,
+	# that will call the module function
+	# Adapted from https://fluxml.ai/MacroTools.jl/dev/utilities/
+	wrapper_dict = copy(template_dict)
+	wrapper_dict[:body] = :(
+		$(module_sym).$(template_dict[:name])(
+			$(strip_types.(template_dict[:args])...);
+			$(strip_types.(template_dict[:kwargs])...)
+		)
+	)
+	MacroTools.combinedef(wrapper_dict)
+end
+
+# ╔═╡ c2f701da-aaa7-4af5-bada-5acb05465b3f
+"""
+    @nb_extract(utp, template)
+
+Create a function out of a `Pluto` notebook updated topology,
+based on a template.
+
+The notebook updated topology `utp` must be a `PlutoDependencyExplorer.NotebookTopology{Pluto.Cell}`,
+with up-to-date topology, filled with references and definitions
+(for instance from [`load_updated_topology`](@ref)).
+
+The signature of the returned function is exactly the one of the `template`.
+The arguments take precedence over the values defined in the notebook.
+
+The updated topology `utp` and the template are then analyzed
+to find the cells that are necessary to evaluate the template body
+(the cells that define `b` and `c` in the last example).
+
+Those cells code is prepended to the template body, to form the function body.
+
+The result of the macro is this fleshed-out function,
+just as if it had been typed by hand.
+Preliminary benchmarks show no overhead.
+
+Remark: `@nb_extract` can be used not only from a running Pluto notebook,
+but from anywhere else (a script, the REPL, ...).
+
+# Examples
+Say in the source notebook there are three cells: `a = 1`, `b = 2a`, `c = 2b`,
+here is how to make a function that return the value `c` from any given `a`:
+```jldoctest
+julia> using PlutoExtractors: load_updated_topology, @nb_extract
+julia> source_path = pkgdir(PlutoExtractors,
+	"test", "notebooks", "source_basic.jl"
+)  # to be replaced with the path of your source notebook
+julia> utp = load_updated_topology(source_path);
+julia> @nb_extract(
+	utp,
+	function fun(a)
+		return c
+	end
+)
+julia> fun(2)
+8
+```
+
+See also [`load_updated_topology`](@ref)
+"""
+macro nb_extract(utp, template)
+	# will put the function definition inside a module,
+	# so that the necessary packages are accessible
+	# both for the macroexpansion phase (to determine dependencies)
+	# and for the function
+	module_sym = gensym(:PlutoExtract)
+
+	(template_dict, given_symbols, needed_symbols) = template_analysis(template)
+
+	# The wrapper expression has to be build beforehand,
+	# to be put at the end of the quote,
+	# to be evaluated in the local scope rather than in toplevel
+	fun_wrapper_expr = fun_wrapper(
+		template_dict,
+		module_sym
+	)
+
+	# `nb_extractor_body` needs to know about the real notebook
+	# so the following can only be done at runtime.
+	# => Just prepare the expressions to be evaluated when the macro is executed.
+	return quote
+		let
+			# utp is not complete yet, but enough to gather the module header
+			header = gather_header($(esc(utp)), $(QuoteNode(given_symbols)))
+			module_expr = get_module_expr(
+				$(QuoteNode(module_sym)),
+				$(esc(utp)),
+				header,
+			)
+			m = $__module__.eval(module_expr)
+
+			# Now can use the utp of the module
+			# (more complete thanks to the macroexpansion,
+			#  that succeeds because the packages are available inside the module)
+			types_expr, fun_expr = nb_extractor_body(
+				m.utp,
+				$(QuoteNode(template_dict)),
+				$(QuoteNode(given_symbols))
+			)
+
+			# Put in the module the "types" expressions (`struct` for instance)
+			# (not allowed in the function)
+			for expr in types_expr
+				Base.eval(m, expr)
+			end
+
+			Base.eval(m, fun_expr)
+		end
+		# This last expression will be evaluated in the caller's scope
+		$(esc(fun_wrapper_expr))
+	end
+end
+
+
+# ╔═╡ 7fe4dc9a-9821-4924-bacb-0cebae1e74bd
+function fake_bind_expr()
+	quote
+		# Code reformatted from Pluto submodule PlutoRunner/src/bonds.jl fakebind
+		# (the one that Pluto inserts in the .jl file)
+		macro bind(def, element)
+		    return quote
+		        local iv = try
+						Base.loaded_modules[
+							Base.PkgId(
+								Base.UUID("6e696c72-6542-2067-7265-42206c756150"),
+								"AbstractPlutoDingetjes"
+							)
+						].Bonds.initial_value
+					catch
+						b -> missing
+					end
+		        local el = $(esc(element))
+		        global $(esc(def)) = Core.applicable(Base.get, el) ?
+					Base.get(el) :
+					iv(el)
+		        el
+		    end
+		end
+	end
+end
+
+# ╔═╡ 56764600-5efa-45bd-bf9e-68dae3bde72c
+function gather_header(utp, given)
+	expressions = Expr[]
+	for cell in utp.cell_order
+		expr = Meta.parse(cell.code)
+		node = utp.nodes[cell]
+
+		# Pluto allows to write markdown strings
+		# without an explicit `using Markdown`.
+		if Symbol("@md_str") in node.macrocalls
+			push!(expressions, :(using Markdown))
+		end
+
+		# Need all usings and imports
+		# to create the full m.utp (with macroexpansion).
+		usings_imports = EE.compute_usings_imports(expr)
+		append!(expressions, usings_imports.usings)
+		append!(expressions, usings_imports.imports)
+	end
+	# Needed for update_with_macroexpand to succeed, if any @bind
+	expr = fake_bind_expr()
+	push!(expressions, expr)
+	expressions
 end
 
 # ╔═╡ 9194537f-8d42-422b-afa2-f86933522efc
@@ -154,6 +344,17 @@ function all_needed_cells(
 	needed
 end
 
+# ╔═╡ 63c26add-ac5a-4a2c-9779-bd6c9710fe1a
+function remove_trailing_semicolon(str)
+	rstrip(c -> c == ';' || isspace(c), str)
+end
+
+# ╔═╡ e4ecb782-85af-4e66-a7af-72eca79bd191
+function has_usings_imports(ex)
+	(; usings, imports) = EE.compute_usings_imports(ex)
+	!isempty(usings) || !isempty(imports)
+end
+
 # ╔═╡ da3fb260-a858-457f-8430-c6a124d1d1e5
 function gather_bind_symbols(ex)
 	symbols = Symbol[]
@@ -171,155 +372,6 @@ function gather_bind_symbols(ex)
 		end
 	end
 	symbols
-end
-
-# ╔═╡ ba256080-73fb-4de4-be72-101318c82029
-strip_types(x::Symbol) = x
-
-# ╔═╡ feadac3a-859c-4915-bfc6-8fa607d6b606
-# This function is used to be able to strip types from the extracted arguments to forward the function call to the gensymed one
-# We want to do something like `fun(a::Something) = MODULE.#xxx#fun(a)`
-function strip_types(x::Expr)::Symbol
-	if Meta.isexpr(x, [:(::), :kw])
-		return strip_types(x.args[1]) # We recursively call strip_types till we reach the symbol or we error
-	else
-		error("This function should only receive either symbols or Expr of the type `x::Something`, `x=something` or `x::Something=something`. Instead `$x` was given as input")
-	end
-end
-
-# ╔═╡ 5c15516e-e3e1-401b-97b5-f4ce60e3a234
-function fun_wrapper(template_dict, module_sym::Symbol)
-	# Wrapper to be evaluated in the caller scope,
-	# that will call the module function
-	# Adapted from https://fluxml.ai/MacroTools.jl/dev/utilities/
-	wrapper_dict = copy(template_dict)
-	wrapper_dict[:body] = :(
-		$(module_sym).$(template_dict[:name])(
-			$(strip_types.(template_dict[:args])...);
-			$(strip_types.(template_dict[:kwargs])...)
-		)
-	)
-	MacroTools.combinedef(wrapper_dict)
-end
-
-# ╔═╡ c2f701da-aaa7-4af5-bada-5acb05465b3f
-"""
-    @nb_extract(utp, template)
-
-Create a function out of a `Pluto` notebook updated topology,
-based on a template.
-
-The notebook updated topology `utp` must be a `PlutoDependencyExplorer.NotebookTopology{Pluto.Cell}`,
-with up-to-date topology, filled with references and definitions
-(for instance from [`load_updated_topology`](@ref)).
-
-The signature of the returned function is exactly the one of the `template`.
-The argument names must match symbols defined in the notebook.
-The arguments values will be used instead of the source notebook ones
-in the evaluation.
-
-The return value of this function is found in the `template` body.
-This body must consist of a single `return` statement.
-The return value can be a single variable (e.g. ` return c`),
-a tuple (e.g. `return (b, c)`), or a named tuple (e.g. `return (; b = b, whatever = c)`).
-
-The updated topology `utp` is then analyzed to find the cells that are necessary
-to evaluate the return value
-(the cells that define `a` and `b` in the last examples).
-
-Those cells code is used as the core of the function body.
-
-The result of the macro is this fleshed-out function,
-just as if it had been typed by hand.
-Preliminary benchmarks show no overhead.
-
-Remark: `@nb_extract` can be used not only from a running Pluto notebook,
-but from anywhere else (a script, the REPL, ...).
-
-# Examples
-Say in the source notebook there are three cells: `a = 1`, `b = 2a`, `c = 2b`,
-here is how to make a function that return the value `c` from any given `a`:
-```jldoctest
-julia> using PlutoExtractors: load_updated_topology, @nb_extract
-julia> source_path = pkgdir(PlutoExtractors,
-	"test", "notebooks", "source_basic.jl"
-)  # to be replaced with the path of your source notebook
-julia> utp = load_updated_topology(source_path);
-julia> @nb_extract(
-	utp,
-	function fun(a)
-		return c
-	end
-)
-julia> fun(2)
-8
-```
-
-See also [`load_nb_with_topology`](@ref)
-"""
-macro nb_extract(utp, template)
-	# will put the function definition inside a module,
-	# so that the necessary packages are accessible
-	# both for the macroexpansion phase (to determine dependencies)
-	# and for the function
-	module_sym = gensym(:PlutoExtract)
-
-	(template_dict, given_symbols, needed_symbols) = template_analysis(template)
-
-	# The wrapper expression has to be build beforehand,
-	# to be put at the end of the quote,
-	# to be evaluated in the local scope rather than in toplevel
-	fun_wrapper_expr = fun_wrapper(
-		template_dict,
-		module_sym
-	)
-
-	# `nb_extractor_body` needs to know about the real notebook
-	# so the following can only be done at runtime.
-	# => Just prepare the expressions to be evaluated when the macro is executed.
-	return quote
-		let
-			# utp is not complete yet, but enough to gather the module header
-			header = gather_header($(esc(utp)), $(QuoteNode(given_symbols)))
-			module_expr = get_module_expr(
-				$(QuoteNode(module_sym)),
-				$(esc(utp)),
-				header,
-			)
-			m = $__module__.eval(module_expr)
-
-			# Now can use the utp of the module
-			# (more complete thanks to the macroexpansion,
-			#  that succeeds because the packages are available inside the module)
-			types_expr, fun_expr = nb_extractor_body(
-				m.utp,
-				$(QuoteNode(template_dict)),
-				$(QuoteNode(given_symbols))
-			)
-
-			# Put in the module the "types" expressions (`struct` for instance)
-			# (not allowed in the function)
-			for expr in types_expr
-				Base.eval(m, expr)
-			end
-
-			Base.eval(m, fun_expr)
-		end
-		# This last expression will be evaluated in the caller's scope
-		$(esc(fun_wrapper_expr))
-	end
-end
-
-
-# ╔═╡ 63c26add-ac5a-4a2c-9779-bd6c9710fe1a
-function remove_trailing_semicolon(str)
-	rstrip(c -> c == ';' || isspace(c), str)
-end
-
-# ╔═╡ e4ecb782-85af-4e66-a7af-72eca79bd191
-function has_usings_imports(ex)
-	(; usings, imports) = EE.compute_usings_imports(ex)
-	!isempty(usings) || !isempty(imports)
 end
 
 # ╔═╡ 58780697-0b89-420c-8b22-a31705ce45e4
@@ -383,58 +435,6 @@ function nb_extractor_body(utp, template_dict::Dict, given_symbols)
 	fun_expr = MacroTools.combinedef(new_dict)
 	
 	return types_expr, fun_expr
-end
-
-# ╔═╡ 7fe4dc9a-9821-4924-bacb-0cebae1e74bd
-function fake_bind_expr()
-	quote
-		# Code reformatted from Pluto submodule PlutoRunner/src/bonds.jl fakebind
-		# (the one that Pluto inserts in the .jl file)
-		macro bind(def, element)
-		    return quote
-		        local iv = try
-						Base.loaded_modules[
-							Base.PkgId(
-								Base.UUID("6e696c72-6542-2067-7265-42206c756150"),
-								"AbstractPlutoDingetjes"
-							)
-						].Bonds.initial_value
-					catch
-						b -> missing
-					end
-		        local el = $(esc(element))
-		        global $(esc(def)) = Core.applicable(Base.get, el) ?
-					Base.get(el) :
-					iv(el)
-		        el
-		    end
-		end
-	end
-end
-
-# ╔═╡ 56764600-5efa-45bd-bf9e-68dae3bde72c
-function gather_header(utp, given)
-	expressions = Expr[]
-	for cell in utp.cell_order
-		expr = Meta.parse(cell.code)
-		node = utp.nodes[cell]
-
-		# Pluto allows to write markdown strings
-		# without an explicit `using Markdown`.
-		if Symbol("@md_str") in node.macrocalls
-			push!(expressions, :(using Markdown))
-		end
-
-		# Need all usings and imports
-		# to create the full m.utp (with macroexpansion).
-		usings_imports = EE.compute_usings_imports(expr)
-		append!(expressions, usings_imports.usings)
-		append!(expressions, usings_imports.imports)
-	end
-	# Needed for update_with_macroexpand to succeed, if any @bind
-	expr = fake_bind_expr()
-	push!(expressions, expr)
-	expressions
 end
 
 # ╔═╡ Cell order:

--- a/src/notebooks/extractors.jl
+++ b/src/notebooks/extractors.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.20.8
+# v0.20.10
 
 #> [frontmatter]
 #> title = ""
@@ -87,7 +87,7 @@ function template_analysis(template::Expr)
 	dict = MacroTools.splitdef(template)
 
 	# symbols that will be given by the caller
-	given_symbols = Symbol[]
+	given_symbols = Set{Symbol}()
 	for arg in Iterators.flatten((dict[:args], dict[:kwargs]))
 		name, _ = MacroTools.splitarg(arg)
 		push!(given_symbols, name)

--- a/src/notebooks/extractors.jl
+++ b/src/notebooks/extractors.jl
@@ -44,7 +44,11 @@ with references and definitions filled.
 
 See also [`@nb_extract`](@ref)
 """
-function load_updated_topology(path::AbstractString)
+function load_updated_topology(
+	path::AbstractString;
+	get_code_str = c -> c.code,
+	get_code_expr = c -> Meta.parse(c.code),
+)
 	nb = Pluto.load_notebook_nobackup(String(path))
 
 	empty_topology = PDE.NotebookTopology{Pluto.Cell}()
@@ -54,8 +58,8 @@ function load_updated_topology(path::AbstractString)
 		empty_topology,  # old topology
 		PDE.all_cells(nb.topology),  # notebook cells
 		PDE.all_cells(nb.topology);  # cells to consider (they changed)
-		get_code_str = c -> c.code,
-		get_code_expr = c -> Meta.parse(c.code),
+		get_code_str,
+		get_code_expr,
     )
 end
 

--- a/src/notebooks/extractors.jl
+++ b/src/notebooks/extractors.jl
@@ -426,7 +426,8 @@ end
 
 # ╔═╡ 8b28bd70-e4d9-4b21-990b-0f072e6a8802
 function update_with_macroexpand(_module, topology::PDE.NotebookTopology)
-	empty_topology = PDE.NotebookTopology{Pluto.Cell}()
+	cell_type = eltype(topology.cell_order)
+	empty_topology = PDE.NotebookTopology{cell_type}()
 	PDE.updated_topology(
 		empty_topology,  # old topology
 		PDE.all_cells(topology),  # notebook cells

--- a/src/notebooks/extractors.jl
+++ b/src/notebooks/extractors.jl
@@ -360,8 +360,7 @@ macro nb_extract(utp, template)
 	# so that the necessary packages are accessible
 	# both for the macroexpansion phase (to determine dependencies)
 	# and for the function
-	module_name = string(gensym(:PlutoExtract))
-	module_sym = Symbol(module_name)
+	module_sym = gensym(:PlutoExtract)
 	
 	# Wrapper to be evaluated in the caller scope,
 	# that will call the module function
@@ -389,7 +388,7 @@ macro nb_extract(utp, template)
 			# utp is not complete yet, but enough to gather the module header
 			header = gather_header($(esc(utp)), $given)
 			module_expr = get_module_expr(
-				Symbol($(module_name)),
+				$(QuoteNode(module_sym)),
 				$(esc(utp)),
 				header,
 			)

--- a/src/notebooks/extractors.jl
+++ b/src/notebooks/extractors.jl
@@ -197,11 +197,11 @@ macro nb_extract(utp, template)
 	return quote
 		let
 			# utp is not complete yet, but enough to gather the module header
-			header = gather_header($(esc(utp)), $(QuoteNode(given_symbols)))
+			header_expressions = gather_header($(esc(utp)), $(QuoteNode(given_symbols)))
 			module_expr = get_module_expr(
 				$(QuoteNode(module_sym)),
 				$(esc(utp)),
-				header,
+				header_expressions,
 			)
 			m = $__module__.eval(module_expr)
 
@@ -282,13 +282,13 @@ function gather_header(utp, given)
 end
 
 # ╔═╡ 9194537f-8d42-422b-afa2-f86933522efc
-function get_module_expr(module_name::Symbol, topology, usings_imports)
+function get_module_expr(module_name::Symbol, topology, header_expressions)
 	Expr(
 		:toplevel,
 		:(
 			module $(module_name)
 				using PlutoExtractors
-				$(usings_imports...)
+				$(header_expressions...)
 				utp = PlutoExtractors.update_with_macroexpand(
 					$(module_name),
 					$(topology)

--- a/src/notebooks/extractors.jl
+++ b/src/notebooks/extractors.jl
@@ -128,6 +128,11 @@ function all_needed_cells(utp::PDE.NotebookTopology, cell;
 	cells
 end
 
+# ╔═╡ 63c26add-ac5a-4a2c-9779-bd6c9710fe1a
+function remove_trailing_semicolon(str)
+	rstrip(c -> c == ';' || isspace(c), str)
+end
+
 # ╔═╡ e4ecb782-85af-4e66-a7af-72eca79bd191
 function has_usings_imports(ex)
 	(; usings, imports) = compute_usings_imports(ex)
@@ -151,12 +156,13 @@ function nb_extractor_body(utp::PDE.NotebookTopology; given=[], outputs=[])
 	tpo = PDE.topological_order(utp)
 	# runnable first to keep its order
 	for cell in tpo.runnable ∩ needed_cells
-		# this returns a :toplevel expression
-		cell_expr = Meta.parse(cell.code)
-		if !has_usings_imports(cell_expr)
+		# Fix "toplevel expression not at top level"
+		code_str = remove_trailing_semicolon(cell.code)
+		code_expr = Meta.parse(code_str)
+		if !has_usings_imports(code_expr)
 			# `using` and `import` are not allowed in a function.
 			# Just ignore, for now (TODO)
-			push!(body.args, cell_expr)
+			push!(body.args, code_expr)
 		end
 	end
 	# get rid of const (not allowed in function body)
@@ -337,6 +343,7 @@ end
 # ╠═2300d1df-94cd-4f7e-bd0b-07bad790464f
 # ╠═efa1e893-34b0-4a14-a0e2-600a365eb717
 # ╠═c71b4e52-5d6a-4a82-b465-b755217198e6
+# ╠═63c26add-ac5a-4a2c-9779-bd6c9710fe1a
 # ╠═e4ecb782-85af-4e66-a7af-72eca79bd191
 # ╠═ea0ba472-50a3-4ab6-a221-0b710b361fca
 # ╠═ba256080-73fb-4de4-be72-101318c82029

--- a/src/notebooks/extractors.jl
+++ b/src/notebooks/extractors.jl
@@ -8,6 +8,18 @@
 using Markdown
 using InteractiveUtils
 
+# This Pluto notebook uses @bind for interactivity. When running this notebook outside of Pluto, the following 'mock version' of @bind gives bound variables a default value (instead of an error).
+macro bind(def, element)
+    #! format: off
+    return quote
+        local iv = try Base.loaded_modules[Base.PkgId(Base.UUID("6e696c72-6542-2067-7265-42206c756150"), "AbstractPlutoDingetjes")].Bonds.initial_value catch; b -> missing; end
+        local el = $(esc(element))
+        global $(esc(def)) = Core.applicable(Base.get, el) ? Base.get(el) : iv(el)
+        el
+    end
+    #! format: on
+end
+
 # ╔═╡ 3e3102e5-9bbd-4592-a749-821ee5e42c7c
 import Pkg
 
@@ -373,6 +385,33 @@ macro nb_extract(utp, template)
 	end
 end
 
+# ╔═╡ 7fe4dc9a-9821-4924-bacb-0cebae1e74bd
+function fake_bind_expr()
+	quote
+		# Code reformatted from Pluto submodule PlutoRunner/src/bonds.jl fakebind
+		# (the one that Pluto inserts in the .jl file)
+		macro bind(def, element)
+		    return quote
+		        local iv = try
+						Base.loaded_modules[
+							Base.PkgId(
+								Base.UUID("6e696c72-6542-2067-7265-42206c756150"),
+								"AbstractPlutoDingetjes"
+							)
+						].Bonds.initial_value
+					catch
+						b -> missing
+					end
+		        local el = $(esc(element))
+		        global $(esc(def)) = Core.applicable(Base.get, el) ?
+					Base.get(el) :
+					iv(el)
+		        el
+		    end
+		end
+	end
+end
+
 # ╔═╡ 56764600-5efa-45bd-bf9e-68dae3bde72c
 function gather_header(utp)
 	expressions = Expr[]
@@ -383,6 +422,11 @@ function gather_header(utp)
 		# without an explicit `using Markdown`.
 		if Symbol("@md_str") in node.macrocalls
 			push!(expressions, :(using Markdown))
+		end
+		# Pluto handles @bind specially, without modules
+		if Symbol("@bind") in node.macrocalls
+			expr = fake_bind_expr()
+			push!(expressions, expr)
 		end
 		usings_imports = EE.compute_usings_imports(expr)
 		append!(expressions, usings_imports.usings)
@@ -446,4 +490,5 @@ end
 # ╠═c2f701da-aaa7-4af5-bada-5acb05465b3f
 # ╠═56764600-5efa-45bd-bf9e-68dae3bde72c
 # ╠═9194537f-8d42-422b-afa2-f86933522efc
+# ╠═7fe4dc9a-9821-4924-bacb-0cebae1e74bd
 # ╠═8b28bd70-e4d9-4b21-990b-0f072e6a8802

--- a/src/notebooks/extractors.jl
+++ b/src/notebooks/extractors.jl
@@ -106,11 +106,8 @@ strip_types(x::Symbol) = x
 # This function is used to be able to strip types from the extracted arguments to forward the function call to the gensymed one
 # We want to do something like `fun(a::Something) = MODULE.#xxx#fun(a)`
 function strip_types(x::Expr)::Symbol
-	if Meta.isexpr(x, [:(::), :kw])
-		return strip_types(x.args[1]) # We recursively call strip_types till we reach the symbol or we error
-	else
-		error("This function should only receive either symbols or Expr of the type `x::Something`, `x=something` or `x::Something=something`. Instead `$x` was given as input")
-	end
+	(arg_name, arg_type, is_splat, default) = MacroTools.splitarg(x)
+	arg_name
 end
 
 # ╔═╡ 5c15516e-e3e1-401b-97b5-f4ce60e3a234

--- a/src/notebooks/extractors.jl
+++ b/src/notebooks/extractors.jl
@@ -330,7 +330,7 @@ function all_needed_cells(
 	utp::PDE.NotebookTopology,
 	given_symbols,
 	needed_symbols
-)
+)::AbstractVector
 	needed = needed_cells_1(utp, given_symbols, needed_symbols)
 	to_visit = copy(needed)
 	while !isempty(to_visit)

--- a/src/notebooks/extractors.jl
+++ b/src/notebooks/extractors.jl
@@ -197,7 +197,7 @@ macro nb_extract(utp, template)
 	return quote
 		let
 			# utp is not complete yet, but enough to gather the module header
-			header_expressions = gather_header($(esc(utp)), $(QuoteNode(given_symbols)))
+			header_expressions = collect_header_expressions($(esc(utp)), $(QuoteNode(given_symbols)))
 			module_expr = get_module_expr(
 				$(QuoteNode(module_sym)),
 				$(esc(utp)),
@@ -257,7 +257,7 @@ function fake_bind_expr()
 end
 
 # ╔═╡ 56764600-5efa-45bd-bf9e-68dae3bde72c
-function gather_header(utp, given)
+function collect_header_expressions(utp, given)
 	expressions = Expr[]
 	for cell in utp.cell_order
 		expr = Meta.parse(cell.code)

--- a/src/notebooks/extractors.jl
+++ b/src/notebooks/extractors.jl
@@ -191,7 +191,7 @@ macro nb_extract(utp, template)
 		module_sym
 	)
 
-	# `nb_extractor_body` needs to know about the real notebook
+	# `nb_extractor_core` needs to know about the real notebook
 	# so the following can only be done at runtime.
 	# => Just prepare the expressions to be evaluated when the macro is executed.
 	return quote
@@ -208,7 +208,7 @@ macro nb_extract(utp, template)
 			# Now can use the utp of the module
 			# (more complete thanks to the macroexpansion,
 			#  that succeeds because the packages are available inside the module)
-			types_expr, fun_expr = nb_extractor_body(
+			types_expr, fun_expr = nb_extractor_core(
 				m.utp,
 				$(QuoteNode(template_dict)),
 				$(QuoteNode(given_symbols)),
@@ -456,7 +456,7 @@ function split_destinations(
 end
 
 # ╔═╡ 58780697-0b89-420c-8b22-a31705ce45e4
-function nb_extractor_body(
+function nb_extractor_core(
 	utp,
 	template_dict::Dict,
 	given_symbols,

--- a/src/notebooks/extractors.jl
+++ b/src/notebooks/extractors.jl
@@ -132,18 +132,19 @@ end
 Create a function out of a `Pluto` notebook updated topology,
 based on a template.
 
-The notebook updated topology `utp` must be a `PlutoDependencyExplorer.NotebookTopology{Pluto.Cell}`,
-with up-to-date topology, filled with references and definitions
-(for instance from [`load_updated_topology`](@ref)).
+The notebook updated topology `utp` is obtained
+from [`load_updated_topology`](@ref).
+This is a shallow first pass that will help determine the required packages.
 
 The signature of the returned function is exactly the one of the `template`.
 The arguments take precedence over the values defined in the notebook.
 
-The updated topology `utp` and the template are then analyzed
+A second pass performed on `utp` and the template are then analyzed
 to find the cells that are necessary to evaluate the template body
-(the cells that define `b` and `c` in the last example).
+(the cells that define `b` and `c` in the example below).
 
-Those cells code is prepended to the template body, to form the function body.
+Those cells code is prepended to the template body,
+to complete the function body.
 
 The result of the macro is this fleshed-out function,
 just as if it had been typed by hand.
@@ -152,7 +153,7 @@ Preliminary benchmarks show no overhead.
 Remark: `@nb_extract` can be used not only from a running Pluto notebook,
 but from anywhere else (a script, the REPL, ...).
 
-# Examples
+# Example
 Say in the source notebook there are three cells: `a = 1`, `b = 2a`, `c = 2b`,
 here is how to make a function that return the value `c` from any given `a`:
 ```jldoctest

--- a/src/notebooks/extractors.jl
+++ b/src/notebooks/extractors.jl
@@ -75,46 +75,6 @@ function load_updated_topology(
     )
 end
 
-# ╔═╡ a8b197ad-765b-475e-9010-d73df9d24c13
-function find_definition_cells(nb::Pluto.Notebook, symbols)
-	filter(
-		cell -> any(in(nb.topology.nodes[cell].definitions), symbols),
-		nb.cells
-	)
-end
-
-# ╔═╡ 447318b6-e302-4f16-b149-52108b4283fe
-find_function_cells(nb::Pluto.Notebook, symbols) = filter(
-	cell -> any(
-		symbol -> (
-			symbol in nb.topology.nodes[cell].funcdefs_with_signatures
-			|| symbol in nb.topology.nodes[cell].funcdefs_without_signatures
-		),
-		symbols
-	),
-	nb.cells
-)
-
-# ╔═╡ 9fb50a81-390d-44bc-8819-e9ed97d1e0de
-function symbols_defined(utp::PDE.NotebookTopology, cell)
-	node = utp.nodes[cell]
-	union(
-		node.definitions,
-		node.funcdefs_with_signatures,
-		node.funcdefs_without_signatures,
-	)
-end
-
-# ╔═╡ 2300d1df-94cd-4f7e-bd0b-07bad790464f
-find_symbols_cells(utp::PDE.NotebookTopology, symbols) = filter(
-	# TODO: this can surely be simplified now
-	cell -> any(
-		symbol -> symbol in symbols_defined(utp, cell),
-		symbols
-	),
-	PDE.all_cells(utp)
-)
-
 # ╔═╡ 68af943e-a9ed-44e0-85a7-452fc62411ea
 # non-recursive version,
 # finds exactly the cells defining the symbols that are not in given_symbols
@@ -488,10 +448,6 @@ end
 # ╠═8037bbf1-fae0-47a3-a768-a089f21349a8
 # ╠═c196fae5-1d7c-4f73-af01-d9a8c21ac5bd
 # ╠═7e8a7524-1ae6-439d-98c6-5b2390014096
-# ╠═a8b197ad-765b-475e-9010-d73df9d24c13
-# ╠═447318b6-e302-4f16-b149-52108b4283fe
-# ╠═9fb50a81-390d-44bc-8819-e9ed97d1e0de
-# ╠═2300d1df-94cd-4f7e-bd0b-07bad790464f
 # ╠═68af943e-a9ed-44e0-85a7-452fc62411ea
 # ╠═efa1e893-34b0-4a14-a0e2-600a365eb717
 # ╠═da3fb260-a858-457f-8430-c6a124d1d1e5

--- a/test/live.jl
+++ b/test/live.jl
@@ -1,7 +1,7 @@
 # to be included by ./runtests.jl
 # where server_session is defined
 
-@testset "Try" begin
+@testset "Basic" begin
 	source_basic_path = pkgdir(PlutoExtractors, "test", "notebooks", "source_basic.jl")
 
 	# "# expected" cells produce an output that the next cell should reproduce

--- a/test/notebooks/extract_from_source_basic.jl
+++ b/test/notebooks/extract_from_source_basic.jl
@@ -157,14 +157,15 @@ md"""
 """
 
 # ╔═╡ 4366181c-9516-436e-8072-31488d4722ab
-PlutoTest.@test_throws ErrorException(
-	"Unable to extract any definition for Any[:non_existing]"
-) @nb_extract(
+@nb_extract(
 	utp,
 	function fun_error_1()
 		return non_existing  # :non_existing is not defined in nb
 	end
 )
+
+# ╔═╡ 45d63dc5-6913-4738-a16f-db3003be6007
+PlutoTest.@test_throws UndefVarError(:non_existing) fun_error_1()
 
 # ╔═╡ Cell order:
 # ╠═64f6372a-eff1-11ec-2395-31d68eda5f3a
@@ -201,3 +202,4 @@ PlutoTest.@test_throws ErrorException(
 # ╠═f4410aeb-b742-4732-9789-640ec466637a
 # ╠═62989d10-0da0-41ca-8d70-f6d2d2bb5435
 # ╠═4366181c-9516-436e-8072-31488d4722ab
+# ╠═45d63dc5-6913-4738-a16f-db3003be6007

--- a/test/notebooks/extract_from_source_basic.jl
+++ b/test/notebooks/extract_from_source_basic.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.22
+# v0.20.8
 
 using Markdown
 using InteractiveUtils
@@ -37,11 +37,11 @@ md"""
 md"## Just one variable"
 
 # ╔═╡ b9e09fd4-f34a-4c72-b979-09bb1b1b57e7
-nb = load_nb_with_topology(source_nb_file)
+utp = load_updated_topology(source_nb_file)
 
 # ╔═╡ a8ac792a-d83b-48ea-a98b-79c43ef76c2e
 @nb_extract(
-	nb,
+	utp,
 	function fun1()
 		return a
 	end
@@ -60,7 +60,7 @@ md"""
 
 # ╔═╡ aada1eb9-5887-4c4f-a796-45217ff8ece7
 @nb_extract(
-	nb,
+	utp,
 	function fun_out_nt_a_c()
 		return (; a = a, c = c)
 	end
@@ -79,7 +79,7 @@ md"""
 
 # ╔═╡ abfcb9bd-8c20-47a9-9f1c-12e75426d6df
 @nb_extract(
-	nb,
+	utp,
 	function fun_a_out_nt_b_c(a)
 		return (; b = b, c = c)
 	end
@@ -98,7 +98,7 @@ md"""
 
 # ╔═╡ 66929e56-fb7f-49fe-a0ce-b4a58b558b37
 @nb_extract(
-	nb,
+	utp,
 	function fun_6(; a=2)
 		return c
 	end
@@ -118,7 +118,7 @@ md"""
 # ╔═╡ 02e44c02-d427-4646-afdc-b52f1e5a9595
 res_inner = let
 	@nb_extract(
-		nb,
+		utp,
 		function inner_fun(a)
 			return c
 		end
@@ -139,7 +139,7 @@ md"""
 
 # ╔═╡ 484fb80e-2722-42b9-bb39-6f2cade9b076
 @nb_extract(
-	nb,
+	utp,
 	function fun_5(a::Int)
 		return c
 	end
@@ -160,7 +160,7 @@ md"""
 PlutoTest.@test_throws ErrorException(
 	"Unable to extract any definition for Any[:non_existing]"
 ) @nb_extract(
-	nb,
+	utp,
 	function fun_error_1()
 		return non_existing  # :non_existing is not defined in nb
 	end

--- a/test/notebooks/extract_from_source_bind.jl
+++ b/test/notebooks/extract_from_source_bind.jl
@@ -56,19 +56,27 @@ Pluto treats @bind special
 utp = load_updated_topology(source_nb_file)
 
 # ╔═╡ a8ac792a-d83b-48ea-a98b-79c43ef76c2e
-@nb_extract(
+PlutoTest.@test_throws ["Please add `a` to the function arguments"] @nb_extract(
 	utp,
 	function fun1()
 		return b
 	end
 )
 
+# ╔═╡ c23487ba-d2e9-4665-b57f-d661b2d16a25
+@nb_extract(
+	utp,
+	function fun2(a)
+		return b
+	end
+)
+
 # ╔═╡ b2b5d93a-faff-4d9f-92da-40bf95efcff6
-fun1_b = fun1()
+fun2_b = fun2(4)
 
 # ╔═╡ 84f703bd-39d4-43a0-8062-34decd68c6bc
-# Default value for a is 3, and b = 2a
-PlutoTest.@test fun1_b == 6
+# The given `a` is 4, and `b = 2a`
+PlutoTest.@test fun2_b == 8
 
 # ╔═╡ Cell order:
 # ╠═64f6372a-eff1-11ec-2395-31d68eda5f3a
@@ -81,5 +89,6 @@ PlutoTest.@test fun1_b == 6
 # ╠═214a48ea-1769-45c8-b113-bb17a1a766b7
 # ╠═b9e09fd4-f34a-4c72-b979-09bb1b1b57e7
 # ╠═a8ac792a-d83b-48ea-a98b-79c43ef76c2e
+# ╠═c23487ba-d2e9-4665-b57f-d661b2d16a25
 # ╠═b2b5d93a-faff-4d9f-92da-40bf95efcff6
 # ╠═84f703bd-39d4-43a0-8062-34decd68c6bc

--- a/test/notebooks/extract_from_source_bind.jl
+++ b/test/notebooks/extract_from_source_bind.jl
@@ -55,13 +55,23 @@ Pluto treats @bind special
 # ╔═╡ b9e09fd4-f34a-4c72-b979-09bb1b1b57e7
 utp = load_updated_topology(source_nb_file)
 
+# ╔═╡ 1edaab0a-c3f1-45d0-9be7-ceee605e1a1c
+md"""
+### Variable needed and not given
+"""
+
 # ╔═╡ a8ac792a-d83b-48ea-a98b-79c43ef76c2e
-PlutoTest.@test_throws ["Please add `a` to the function arguments"] @nb_extract(
+PlutoTest.@test_throws ["Please add `a` to the given arguments"] @nb_extract(
 	utp,
 	function fun1()
 		return b
 	end
 )
+
+# ╔═╡ 43f28cb1-ac86-49c0-8f9b-87e7cbc1287c
+md"""
+### Variable given
+"""
 
 # ╔═╡ c23487ba-d2e9-4665-b57f-d661b2d16a25
 @nb_extract(
@@ -78,6 +88,36 @@ fun2_b = fun2(4)
 # The given `a` is 4, and `b = 2a`
 PlutoTest.@test fun2_b == 8
 
+# ╔═╡ dee52de0-d645-4ed5-8c9c-5b9b137be76a
+md"""
+### Variable not needed at all
+"""
+
+# ╔═╡ 193ebf2a-d2d3-4265-890f-6e808a88b907
+@nb_extract(
+	utp,
+	function fun3()
+		return d
+	end
+)
+
+# ╔═╡ b0c1045a-d7a6-4cc8-a2d0-84328d2b3629
+md"""
+### Assignements
+
+Check that @bind statements buried under assignments
+aptly error with a meaningful message.
+(until it is possible to get the current value of a slider)
+"""
+
+# ╔═╡ 0882779d-e882-4350-a714-49a9558c762c
+PlutoTest.@test_throws ["Please add `xe` to the given arguments"] @nb_extract(
+	utp,
+	function fun4()
+		return xe
+	end
+)
+
 # ╔═╡ Cell order:
 # ╠═64f6372a-eff1-11ec-2395-31d68eda5f3a
 # ╠═0758f6c1-f7e0-4f9e-911a-c5d21f4b0d50
@@ -86,9 +126,15 @@ PlutoTest.@test fun2_b == 8
 # ╠═23e9bd17-9d56-4a4d-a76c-03095b959465
 # ╠═35bab28c-477c-43dd-b339-13cfdbf2f33e
 # ╟─89dd6ff4-2495-4bd1-96ef-8962f8041cf3
-# ╠═214a48ea-1769-45c8-b113-bb17a1a766b7
+# ╟─214a48ea-1769-45c8-b113-bb17a1a766b7
 # ╠═b9e09fd4-f34a-4c72-b979-09bb1b1b57e7
+# ╟─1edaab0a-c3f1-45d0-9be7-ceee605e1a1c
 # ╠═a8ac792a-d83b-48ea-a98b-79c43ef76c2e
+# ╟─43f28cb1-ac86-49c0-8f9b-87e7cbc1287c
 # ╠═c23487ba-d2e9-4665-b57f-d661b2d16a25
 # ╠═b2b5d93a-faff-4d9f-92da-40bf95efcff6
 # ╠═84f703bd-39d4-43a0-8062-34decd68c6bc
+# ╟─dee52de0-d645-4ed5-8c9c-5b9b137be76a
+# ╠═193ebf2a-d2d3-4265-890f-6e808a88b907
+# ╟─b0c1045a-d7a6-4cc8-a2d0-84328d2b3629
+# ╠═0882779d-e882-4350-a714-49a9558c762c

--- a/test/notebooks/extract_from_source_bind.jl
+++ b/test/notebooks/extract_from_source_bind.jl
@@ -1,0 +1,85 @@
+### A Pluto.jl notebook ###
+# v0.20.8
+
+using Markdown
+using InteractiveUtils
+
+# This Pluto notebook uses @bind for interactivity. When running this notebook outside of Pluto, the following 'mock version' of @bind gives bound variables a default value (instead of an error).
+macro bind(def, element)
+    #! format: off
+    return quote
+        local iv = try Base.loaded_modules[Base.PkgId(Base.UUID("6e696c72-6542-2067-7265-42206c756150"), "AbstractPlutoDingetjes")].Bonds.initial_value catch; b -> missing; end
+        local el = $(esc(element))
+        global $(esc(def)) = Core.applicable(Base.get, el) ? Base.get(el) : iv(el)
+        el
+    end
+    #! format: on
+end
+
+# ╔═╡ 64f6372a-eff1-11ec-2395-31d68eda5f3a
+import Pkg
+
+# ╔═╡ 0758f6c1-f7e0-4f9e-911a-c5d21f4b0d50
+# ╠═╡ skip_as_script = true
+#=╠═╡
+begin
+	Pkg.activate(Base.current_project())
+	using Revise  # just to be sure Revise is called first (is it necessary ?)
+end
+  ╠═╡ =#
+
+# ╔═╡ ca7520d3-c140-411d-b80d-c9cb03c7724d
+using PlutoExtractors
+
+# ╔═╡ 780d2266-5ca3-413c-b354-6fb8c782bb30
+import PlutoTest
+
+# ╔═╡ 23e9bd17-9d56-4a4d-a76c-03095b959465
+root_dir = pkgdir(PlutoExtractors)
+
+# ╔═╡ 35bab28c-477c-43dd-b339-13cfdbf2f33e
+source_nb_file = joinpath(root_dir, "test", "notebooks", "source_bind.jl")
+
+# ╔═╡ 89dd6ff4-2495-4bd1-96ef-8962f8041cf3
+md"""
+# Tests
+"""
+
+# ╔═╡ 214a48ea-1769-45c8-b113-bb17a1a766b7
+md"""
+# Notebook with @bind
+
+Pluto treats @bind special
+"""
+
+# ╔═╡ b9e09fd4-f34a-4c72-b979-09bb1b1b57e7
+utp = load_updated_topology(source_nb_file)
+
+# ╔═╡ a8ac792a-d83b-48ea-a98b-79c43ef76c2e
+@nb_extract(
+	utp,
+	function fun1()
+		return b
+	end
+)
+
+# ╔═╡ b2b5d93a-faff-4d9f-92da-40bf95efcff6
+fun1_b = fun1()
+
+# ╔═╡ 84f703bd-39d4-43a0-8062-34decd68c6bc
+# Default value for a is 3, and b = 2a
+PlutoTest.@test fun1_b == 6
+
+# ╔═╡ Cell order:
+# ╠═64f6372a-eff1-11ec-2395-31d68eda5f3a
+# ╠═0758f6c1-f7e0-4f9e-911a-c5d21f4b0d50
+# ╠═ca7520d3-c140-411d-b80d-c9cb03c7724d
+# ╠═780d2266-5ca3-413c-b354-6fb8c782bb30
+# ╠═23e9bd17-9d56-4a4d-a76c-03095b959465
+# ╠═35bab28c-477c-43dd-b339-13cfdbf2f33e
+# ╟─89dd6ff4-2495-4bd1-96ef-8962f8041cf3
+# ╠═214a48ea-1769-45c8-b113-bb17a1a766b7
+# ╠═b9e09fd4-f34a-4c72-b979-09bb1b1b57e7
+# ╠═a8ac792a-d83b-48ea-a98b-79c43ef76c2e
+# ╠═b2b5d93a-faff-4d9f-92da-40bf95efcff6
+# ╠═84f703bd-39d4-43a0-8062-34decd68c6bc

--- a/test/notebooks/extract_from_source_callables.jl
+++ b/test/notebooks/extract_from_source_callables.jl
@@ -1,0 +1,169 @@
+### A Pluto.jl notebook ###
+# v0.20.8
+
+using Markdown
+using InteractiveUtils
+
+# ╔═╡ 51df9d39-7d35-49e1-bac3-7354882bb141
+import Pkg
+
+# ╔═╡ 67aa154f-a294-41ce-aea5-36cf5ddcf1de
+# ╠═╡ skip_as_script = true
+#=╠═╡
+begin
+	Pkg.activate(Base.current_project())
+	using Revise  # just to be sure Revise is called first (is it necessary ?)
+end
+  ╠═╡ =#
+
+# ╔═╡ 640d5a61-0e23-4614-96d7-6d79e015eee3
+using PlutoExtractors
+
+# ╔═╡ 9f58ade4-c81b-45fb-a497-4f7503b94e13
+import PlutoTest
+
+# ╔═╡ 88334e90-1486-40e2-84d5-8f49eda045fe
+root_dir = pkgdir(PlutoExtractors)
+
+# ╔═╡ d5a36c7c-95bf-4bd3-96d7-1b2392eeec94
+source_nb_file = joinpath(root_dir, "test", "notebooks", "source_callables.jl")
+
+# ╔═╡ f3ee4c34-3c96-4254-aa07-34d67efaedc3
+utp = load_updated_topology(source_nb_file)
+
+# ╔═╡ 8411b188-54d9-43fd-9d47-6bd6d7f5ed86
+md"""
+# Tests
+"""
+
+# ╔═╡ e4837658-a2ef-4dfa-8cb0-f909eac426b6
+md"""
+## Without global
+"""
+
+# ╔═╡ 525f5fcc-efd1-48ef-8aeb-9c184e54a50d
+@nb_extract(
+	utp,
+	function fun_1(x)
+		return scaled_x
+	end
+)
+
+# ╔═╡ 9cf1c8ea-6043-41cd-abdd-595ebf5254b2
+PlutoTest.@test fun_1(5.0) == 15.0
+
+# ╔═╡ 9768ce53-304b-4794-9de2-d09d6b39cf05
+md"""
+## With global
+"""
+
+# ╔═╡ 79059923-0737-40fb-80d9-5381bdece98a
+@nb_extract(
+	utp,
+	function fun_2(x)
+		return scaled_x_2
+	end
+)
+
+# ╔═╡ 5e4d4b3a-aa18-425e-bc31-cf5a87d8a196
+fun_2(3.0)
+
+# ╔═╡ 5419c947-011c-449c-ba24-479d43fc6d2c
+md"""
+## Functions
+"""
+
+# ╔═╡ ace85006-e9c4-43c3-a004-6f2b818afd49
+@nb_extract(
+	utp,
+	function fun_3(x)
+		return fun_fun_long(x)
+	end
+)
+
+# ╔═╡ ce8c6503-9475-4261-836a-61a0859b2cc6
+PlutoTest.@test fun_3(3) == 27
+
+# ╔═╡ 74986ddb-f85a-477b-b036-6a534ea65e56
+@nb_extract(
+	utp,
+	function fun_4()
+		return d
+	end
+)
+
+# ╔═╡ e925b852-cf7b-4545-8bd3-5c3b0cb2fde4
+PlutoTest.@test fun_4() == 64
+
+# ╔═╡ f255eb1a-9fc1-4dfa-812e-faaaa42ed666
+@nb_extract(
+	utp,
+	function fun_5()
+		return fun_capt_a()
+	end
+)
+
+# ╔═╡ fce2c7fb-f9be-45a7-9a46-211012ecae9d
+PlutoTest.@test fun_5() == 2
+
+# ╔═╡ 91f52bb6-036e-472f-98d5-8e5dedd236e6
+@nb_extract(
+	utp,
+	function fun_6(a)
+		return fun_capt_a()
+	end
+)
+
+# ╔═╡ c04f2ae1-60e7-4edd-9f66-6155eb8a34d6
+PlutoTest.@test fun_6(3) == 3
+
+# ╔═╡ 52cd299d-7e5c-4342-aedb-81a55a5253b1
+@nb_extract(
+	utp,
+	function fun_7(b)
+		return fun_capt_a_b()
+	end
+)
+
+# ╔═╡ d5661bd4-6cfe-4a0f-a4a4-db60d5dd3c73
+PlutoTest.@test fun_7(3) == 5
+
+# ╔═╡ 2386b27f-1c20-4884-9898-2acd57205e54
+@nb_extract(
+	utp,
+	function fun_8(a)
+		return fun_chain()
+	end
+)
+
+# ╔═╡ 99e54bbc-535b-4b5e-87b6-9df5fbebb3e2
+fun_8(2)
+
+# ╔═╡ Cell order:
+# ╠═51df9d39-7d35-49e1-bac3-7354882bb141
+# ╠═67aa154f-a294-41ce-aea5-36cf5ddcf1de
+# ╠═640d5a61-0e23-4614-96d7-6d79e015eee3
+# ╠═9f58ade4-c81b-45fb-a497-4f7503b94e13
+# ╠═88334e90-1486-40e2-84d5-8f49eda045fe
+# ╠═d5a36c7c-95bf-4bd3-96d7-1b2392eeec94
+# ╠═f3ee4c34-3c96-4254-aa07-34d67efaedc3
+# ╠═8411b188-54d9-43fd-9d47-6bd6d7f5ed86
+# ╠═e4837658-a2ef-4dfa-8cb0-f909eac426b6
+# ╠═525f5fcc-efd1-48ef-8aeb-9c184e54a50d
+# ╠═9cf1c8ea-6043-41cd-abdd-595ebf5254b2
+# ╠═9768ce53-304b-4794-9de2-d09d6b39cf05
+# ╠═79059923-0737-40fb-80d9-5381bdece98a
+# ╠═5e4d4b3a-aa18-425e-bc31-cf5a87d8a196
+# ╠═5419c947-011c-449c-ba24-479d43fc6d2c
+# ╠═ace85006-e9c4-43c3-a004-6f2b818afd49
+# ╠═ce8c6503-9475-4261-836a-61a0859b2cc6
+# ╠═74986ddb-f85a-477b-b036-6a534ea65e56
+# ╠═e925b852-cf7b-4545-8bd3-5c3b0cb2fde4
+# ╠═f255eb1a-9fc1-4dfa-812e-faaaa42ed666
+# ╠═fce2c7fb-f9be-45a7-9a46-211012ecae9d
+# ╠═91f52bb6-036e-472f-98d5-8e5dedd236e6
+# ╠═c04f2ae1-60e7-4edd-9f66-6155eb8a34d6
+# ╠═52cd299d-7e5c-4342-aedb-81a55a5253b1
+# ╠═d5661bd4-6cfe-4a0f-a4a4-db60d5dd3c73
+# ╠═2386b27f-1c20-4884-9898-2acd57205e54
+# ╠═99e54bbc-535b-4b5e-87b6-9df5fbebb3e2

--- a/test/notebooks/extract_from_source_consts.jl
+++ b/test/notebooks/extract_from_source_consts.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.22
+# v0.20.8
 
 using Markdown
 using InteractiveUtils
@@ -37,11 +37,11 @@ md"""
 md"## Just one variable"
 
 # ╔═╡ a946286a-cef8-49e3-a98c-f87721f3d80d
-nb = load_nb_with_topology(source_nb_file)
+utp = load_updated_topology(source_nb_file)
 
 # ╔═╡ f064422c-b72a-4450-844f-4cb7172bd753
 @nb_extract(
-	nb,
+	utp,
 	function fun_out_a()
 		return a
 	end

--- a/test/notebooks/extract_from_source_markdown.jl
+++ b/test/notebooks/extract_from_source_markdown.jl
@@ -1,0 +1,68 @@
+### A Pluto.jl notebook ###
+# v0.20.8
+
+using Markdown
+using InteractiveUtils
+
+# ╔═╡ 64f6372a-eff1-11ec-2395-31d68eda5f3a
+import Pkg
+
+# ╔═╡ 0758f6c1-f7e0-4f9e-911a-c5d21f4b0d50
+# ╠═╡ skip_as_script = true
+#=╠═╡
+begin
+	Pkg.activate(Base.current_project())
+	using Revise  # just to be sure Revise is called first (is it necessary ?)
+end
+  ╠═╡ =#
+
+# ╔═╡ ca7520d3-c140-411d-b80d-c9cb03c7724d
+using PlutoExtractors
+
+# ╔═╡ 780d2266-5ca3-413c-b354-6fb8c782bb30
+import PlutoTest
+
+# ╔═╡ 23e9bd17-9d56-4a4d-a76c-03095b959465
+root_dir = pkgdir(PlutoExtractors)
+
+# ╔═╡ 35bab28c-477c-43dd-b339-13cfdbf2f33e
+source_nb_file = joinpath(root_dir, "test", "notebooks", "source_markdown.jl")
+
+# ╔═╡ 89dd6ff4-2495-4bd1-96ef-8962f8041cf3
+md"""
+# Tests
+"""
+
+# ╔═╡ 214a48ea-1769-45c8-b113-bb17a1a766b7
+md"## Just one variable"
+
+# ╔═╡ b9e09fd4-f34a-4c72-b979-09bb1b1b57e7
+utp = load_updated_topology(source_nb_file)
+
+# ╔═╡ a8ac792a-d83b-48ea-a98b-79c43ef76c2e
+@nb_extract(
+	utp,
+	function fun1()
+		return b
+	end
+)
+
+# ╔═╡ b2b5d93a-faff-4d9f-92da-40bf95efcff6
+fun1_b = fun1()
+
+# ╔═╡ 84f703bd-39d4-43a0-8062-34decd68c6bc
+PlutoTest.@test fun1_b == 2
+
+# ╔═╡ Cell order:
+# ╠═64f6372a-eff1-11ec-2395-31d68eda5f3a
+# ╠═0758f6c1-f7e0-4f9e-911a-c5d21f4b0d50
+# ╠═ca7520d3-c140-411d-b80d-c9cb03c7724d
+# ╠═780d2266-5ca3-413c-b354-6fb8c782bb30
+# ╠═23e9bd17-9d56-4a4d-a76c-03095b959465
+# ╠═35bab28c-477c-43dd-b339-13cfdbf2f33e
+# ╟─89dd6ff4-2495-4bd1-96ef-8962f8041cf3
+# ╟─214a48ea-1769-45c8-b113-bb17a1a766b7
+# ╠═b9e09fd4-f34a-4c72-b979-09bb1b1b57e7
+# ╠═a8ac792a-d83b-48ea-a98b-79c43ef76c2e
+# ╠═b2b5d93a-faff-4d9f-92da-40bf95efcff6
+# ╠═84f703bd-39d4-43a0-8062-34decd68c6bc

--- a/test/notebooks/extract_from_source_semicolon.jl
+++ b/test/notebooks/extract_from_source_semicolon.jl
@@ -87,7 +87,7 @@ b_code = utp.codes[b_cell]
 EEE.pretransform_pluto(b_code.parsedcode)
 
 # ╔═╡ 1d54eab5-af3a-400d-90d8-97be0cffe35b
-PlutoExtractors.nb_extractor_body(utp, given=[], outputs=[:b])
+PlutoExtractors.nb_extractor_core(utp, given=[], outputs=[:b])
 
 # ╔═╡ Cell order:
 # ╠═64f6372a-eff1-11ec-2395-31d68eda5f3a

--- a/test/notebooks/extract_from_source_semicolon.jl
+++ b/test/notebooks/extract_from_source_semicolon.jl
@@ -1,0 +1,68 @@
+### A Pluto.jl notebook ###
+# v0.20.8
+
+using Markdown
+using InteractiveUtils
+
+# ╔═╡ 64f6372a-eff1-11ec-2395-31d68eda5f3a
+import Pkg
+
+# ╔═╡ 0758f6c1-f7e0-4f9e-911a-c5d21f4b0d50
+# ╠═╡ skip_as_script = true
+#=╠═╡
+begin
+	Pkg.activate(Base.current_project())
+	using Revise  # just to be sure Revise is called first (is it necessary ?)
+end
+  ╠═╡ =#
+
+# ╔═╡ ca7520d3-c140-411d-b80d-c9cb03c7724d
+using PlutoExtractors
+
+# ╔═╡ 780d2266-5ca3-413c-b354-6fb8c782bb30
+import PlutoTest
+
+# ╔═╡ 23e9bd17-9d56-4a4d-a76c-03095b959465
+root_dir = pkgdir(PlutoExtractors)
+
+# ╔═╡ 35bab28c-477c-43dd-b339-13cfdbf2f33e
+source_nb_file = joinpath(root_dir, "test", "notebooks", "source_semicolon.jl")
+
+# ╔═╡ 89dd6ff4-2495-4bd1-96ef-8962f8041cf3
+md"""
+# Tests
+"""
+
+# ╔═╡ 214a48ea-1769-45c8-b113-bb17a1a766b7
+md"## Just one variable"
+
+# ╔═╡ b9e09fd4-f34a-4c72-b979-09bb1b1b57e7
+utp = load_updated_topology(source_nb_file)
+
+# ╔═╡ a8ac792a-d83b-48ea-a98b-79c43ef76c2e
+@nb_extract(
+	utp,
+	function fun1()
+		return b
+	end
+)
+
+# ╔═╡ b2b5d93a-faff-4d9f-92da-40bf95efcff6
+fun1_b = fun1()
+
+# ╔═╡ 4c009a24-8098-4803-9396-43598e2c382d
+PlutoTest.@test fun1_b == 1
+
+# ╔═╡ Cell order:
+# ╠═64f6372a-eff1-11ec-2395-31d68eda5f3a
+# ╠═0758f6c1-f7e0-4f9e-911a-c5d21f4b0d50
+# ╠═ca7520d3-c140-411d-b80d-c9cb03c7724d
+# ╠═780d2266-5ca3-413c-b354-6fb8c782bb30
+# ╠═23e9bd17-9d56-4a4d-a76c-03095b959465
+# ╠═35bab28c-477c-43dd-b339-13cfdbf2f33e
+# ╟─89dd6ff4-2495-4bd1-96ef-8962f8041cf3
+# ╟─214a48ea-1769-45c8-b113-bb17a1a766b7
+# ╠═b9e09fd4-f34a-4c72-b979-09bb1b1b57e7
+# ╠═a8ac792a-d83b-48ea-a98b-79c43ef76c2e
+# ╠═b2b5d93a-faff-4d9f-92da-40bf95efcff6
+# ╠═4c009a24-8098-4803-9396-43598e2c382d

--- a/test/notebooks/extract_from_source_semicolon.jl
+++ b/test/notebooks/extract_from_source_semicolon.jl
@@ -19,8 +19,14 @@ end
 # ╔═╡ ca7520d3-c140-411d-b80d-c9cb03c7724d
 using PlutoExtractors
 
+# ╔═╡ 82342dfb-118c-44d4-9c94-04bd57c8faad
+import PlutoDependencyExplorer as PDE
+
 # ╔═╡ 780d2266-5ca3-413c-b354-6fb8c782bb30
 import PlutoTest
+
+# ╔═╡ becbb9c2-384a-4f8d-9200-b34f248c7aa0
+EEE = PDE.ExpressionExplorerExtras
 
 # ╔═╡ 23e9bd17-9d56-4a4d-a76c-03095b959465
 root_dir = pkgdir(PlutoExtractors)
@@ -50,14 +56,46 @@ utp = load_updated_topology(source_nb_file)
 # ╔═╡ b2b5d93a-faff-4d9f-92da-40bf95efcff6
 fun1_b = fun1()
 
+# ╔═╡ 8ffeb150-6cbc-470b-947a-c094ab0bddfc
+@code_typed fun1()
+
 # ╔═╡ 4c009a24-8098-4803-9396-43598e2c382d
-PlutoTest.@test fun1_b == 1
+PlutoTest.@test fun1_b == 2
+
+# ╔═╡ 343b1d66-2801-4c31-81f9-1c252bb4d337
+md"""
+# Debug
+"""
+
+# ╔═╡ 1dce7e48-e607-4d03-acdb-37010d72c758
+b_cell = filter(
+	c -> contains(c.code, "b ="),
+	PDE.all_cells(utp)
+) |> only
+
+# ╔═╡ 0cc44f46-f5ab-45c2-a20b-1fb1d610697b
+b_node = utp.nodes[b_cell]
+
+# ╔═╡ d118c09b-d70f-4f24-be30-122a3c18abd6
+# true (but should not be part of the test suite)
+b_node.definitions == Set([:b])
+
+# ╔═╡ 30f9606c-134c-4717-82d4-9b6b031116bb
+b_code = utp.codes[b_cell]
+
+# ╔═╡ af63b9bf-9deb-43c9-b9ae-65a74e7fe8e7
+EEE.pretransform_pluto(b_code.parsedcode)
+
+# ╔═╡ 1d54eab5-af3a-400d-90d8-97be0cffe35b
+PlutoExtractors.nb_extractor_body(utp, given=[], outputs=[:b])
 
 # ╔═╡ Cell order:
 # ╠═64f6372a-eff1-11ec-2395-31d68eda5f3a
 # ╠═0758f6c1-f7e0-4f9e-911a-c5d21f4b0d50
+# ╠═82342dfb-118c-44d4-9c94-04bd57c8faad
 # ╠═ca7520d3-c140-411d-b80d-c9cb03c7724d
 # ╠═780d2266-5ca3-413c-b354-6fb8c782bb30
+# ╠═becbb9c2-384a-4f8d-9200-b34f248c7aa0
 # ╠═23e9bd17-9d56-4a4d-a76c-03095b959465
 # ╠═35bab28c-477c-43dd-b339-13cfdbf2f33e
 # ╟─89dd6ff4-2495-4bd1-96ef-8962f8041cf3
@@ -65,4 +103,12 @@ PlutoTest.@test fun1_b == 1
 # ╠═b9e09fd4-f34a-4c72-b979-09bb1b1b57e7
 # ╠═a8ac792a-d83b-48ea-a98b-79c43ef76c2e
 # ╠═b2b5d93a-faff-4d9f-92da-40bf95efcff6
+# ╠═8ffeb150-6cbc-470b-947a-c094ab0bddfc
 # ╠═4c009a24-8098-4803-9396-43598e2c382d
+# ╠═343b1d66-2801-4c31-81f9-1c252bb4d337
+# ╠═1dce7e48-e607-4d03-acdb-37010d72c758
+# ╠═0cc44f46-f5ab-45c2-a20b-1fb1d610697b
+# ╠═d118c09b-d70f-4f24-be30-122a3c18abd6
+# ╠═30f9606c-134c-4717-82d4-9b6b031116bb
+# ╠═af63b9bf-9deb-43c9-b9ae-65a74e7fe8e7
+# ╠═1d54eab5-af3a-400d-90d8-97be0cffe35b

--- a/test/notebooks/extract_from_source_types.jl
+++ b/test/notebooks/extract_from_source_types.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.9
+# v0.20.8
 
 using Markdown
 using InteractiveUtils
@@ -38,7 +38,7 @@ md"## Types
 "
 
 # ╔═╡ f3ee4c34-3c96-4254-aa07-34d67efaedc3
-nb = load_nb_with_topology(source_nb_file)
+utp = load_updated_topology(source_nb_file)
 
 # ╔═╡ fafc2698-d303-4ee8-a9d1-a8a1dc523d2b
 md"""
@@ -65,7 +65,7 @@ md"""
 
 # ╔═╡ 525f5fcc-efd1-48ef-8aeb-9c184e54a50d
 @nb_extract(
-	nb,
+	utp,
 	function fun_1()
 		return b
 	end

--- a/test/notebooks/extract_from_source_types.jl
+++ b/test/notebooks/extract_from_source_types.jl
@@ -77,6 +77,26 @@ fun_1()
 # ╔═╡ 9cf1c8ea-6043-41cd-abdd-595ebf5254b2
 PlutoTest.@test fun_1() == 2
 
+# ╔═╡ 6f6178c8-9c47-4ccb-a8a6-bfb6ac79d30f
+md"""
+### Sub/supertypes
+
+Sensitive to [Julia#50354](https://github.com/JuliaLang/julia/issues/50354) ?
+"""
+
+# ╔═╡ 919bd4ba-6fe2-4641-b7b7-1c184f97679d
+#  Can't get the module yet, so test inside the function
+@nb_extract(
+	utp,
+	function fun_2()
+		sup_match = supertype(Point) === AbstractPoint
+		return sup_match
+	end
+)
+
+# ╔═╡ 175535b1-9599-45e5-a428-8282f99ee50d
+PlutoTest.@test fun_2() === true
+
 # ╔═╡ Cell order:
 # ╠═51df9d39-7d35-49e1-bac3-7354882bb141
 # ╠═67aa154f-a294-41ce-aea5-36cf5ddcf1de
@@ -94,3 +114,6 @@ PlutoTest.@test fun_1() == 2
 # ╠═525f5fcc-efd1-48ef-8aeb-9c184e54a50d
 # ╠═b8879c23-6aec-435a-a875-e30ebd1b4d5a
 # ╠═9cf1c8ea-6043-41cd-abdd-595ebf5254b2
+# ╠═6f6178c8-9c47-4ccb-a8a6-bfb6ac79d30f
+# ╠═919bd4ba-6fe2-4641-b7b7-1c184f97679d
+# ╠═175535b1-9599-45e5-a428-8282f99ee50d

--- a/test/notebooks/extract_from_source_types.jl
+++ b/test/notebooks/extract_from_source_types.jl
@@ -40,24 +40,6 @@ md"## Types
 # ╔═╡ f3ee4c34-3c96-4254-aa07-34d67efaedc3
 utp = load_updated_topology(source_nb_file)
 
-# ╔═╡ fafc2698-d303-4ee8-a9d1-a8a1dc523d2b
-md"""
-#### Copied by hand (workaround)
-
-Types will need some special handling, as they must be toplevel
-(they can't be defined inside a function).
-Until then, they have to be copied by hand.
-"""
-
-# ╔═╡ 90e0bfa8-9b4c-4be0-9733-e32a7e0ca5c9
-abstract type AbstractPoint end
-
-# ╔═╡ e67c92e5-26b6-4a8a-9f07-f23e94c83dbb
-struct Point{F<:Real} <: AbstractPoint
-	x::F
-	y::F
-end
-
 # ╔═╡ e4837658-a2ef-4dfa-8cb0-f909eac426b6
 md"""
 ### Tests
@@ -107,9 +89,6 @@ PlutoTest.@test fun_2() === true
 # ╠═8411b188-54d9-43fd-9d47-6bd6d7f5ed86
 # ╠═53c808e9-a4bc-4fbc-b186-41532f54e7f8
 # ╠═f3ee4c34-3c96-4254-aa07-34d67efaedc3
-# ╠═fafc2698-d303-4ee8-a9d1-a8a1dc523d2b
-# ╠═90e0bfa8-9b4c-4be0-9733-e32a7e0ca5c9
-# ╠═e67c92e5-26b6-4a8a-9f07-f23e94c83dbb
 # ╠═e4837658-a2ef-4dfa-8cb0-f909eac426b6
 # ╠═525f5fcc-efd1-48ef-8aeb-9c184e54a50d
 # ╠═b8879c23-6aec-435a-a875-e30ebd1b4d5a

--- a/test/notebooks/extract_from_source_unpack.jl
+++ b/test/notebooks/extract_from_source_unpack.jl
@@ -73,6 +73,9 @@ md"""
 ## Debug
 """
 
+# ╔═╡ d12b6a5b-1e35-42af-bf89-3959565464ae
+utp.unresolved_cells
+
 # ╔═╡ 198d4900-9ae1-456f-b1cf-3c26a2d8249a
 unpack_ac_cell = filter(
 	c -> contains(c.code, "@unpack a, c ="),
@@ -110,6 +113,7 @@ EEE.pretransform_pluto(unpack_ac_code.parsedcode)
 # ╠═21f86448-721a-4ffe-a098-1482071de585
 # ╠═737782bb-ea44-41b4-b467-da42793fd616
 # ╠═d3341aee-be88-4f4c-a25b-7f2342a98591
+# ╠═d12b6a5b-1e35-42af-bf89-3959565464ae
 # ╠═198d4900-9ae1-456f-b1cf-3c26a2d8249a
 # ╠═1f19f8ec-46e5-48d7-a557-15db25bc12ff
 # ╠═d011ab60-c791-43e4-babc-675be0a8b709

--- a/test/notebooks/extract_from_source_unpack.jl
+++ b/test/notebooks/extract_from_source_unpack.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.22
+# v0.20.8
 
 using Markdown
 using InteractiveUtils
@@ -25,8 +25,14 @@ using PlutoExtractors
 # ╔═╡ 63066171-c4e6-46e6-8e63-eb50f6c70ed1
 using LinearAlgebra: dot  # `dot` is needed for the test
 
+# ╔═╡ 5d55d8df-ba97-4ebc-9d96-35ff9cd11bd4
+import PlutoDependencyExplorer as PDE
+
 # ╔═╡ 9f58ade4-c81b-45fb-a497-4f7503b94e13
 import PlutoTest
+
+# ╔═╡ 6fc87b31-9206-4ccc-87a6-ad37b0d25415
+EEE = PDE.ExpressionExplorerExtras
 
 # ╔═╡ 88334e90-1486-40e2-84d5-8f49eda045fe
 root_dir = pkgdir(PlutoExtractors)
@@ -35,7 +41,10 @@ root_dir = pkgdir(PlutoExtractors)
 source_nb_file = joinpath(root_dir, "test", "notebooks", "source_unpack.jl")
 
 # ╔═╡ f3ee4c34-3c96-4254-aa07-34d67efaedc3
-nb = load_nb_with_topology(source_nb_file)
+utp = load_updated_topology(source_nb_file)
+
+# ╔═╡ 155b072a-d32f-4062-ad4e-1ab9792614ae
+typeof(utp.codes)
 
 # ╔═╡ 8411b188-54d9-43fd-9d47-6bd6d7f5ed86
 md"""
@@ -50,7 +59,7 @@ md"## Regular
 
 # ╔═╡ 21f86448-721a-4ffe-a098-1482071de585
 @nb_extract(
-	nb,
+	utp,
 	function fun1()
 		return a, c
 	end
@@ -65,25 +74,37 @@ md"""
 """
 
 # ╔═╡ 198d4900-9ae1-456f-b1cf-3c26a2d8249a
-unpack_ac_cell = filter(c -> contains(c.code, "@unpack a, c ="), nb.cells) |> only
+unpack_ac_cell = filter(
+	c -> contains(c.code, "@unpack a, c ="),
+	PDE.all_cells(utp)
+) |> only
 
 # ╔═╡ 1f19f8ec-46e5-48d7-a557-15db25bc12ff
-unpack_ac_node = nb.topology.nodes[unpack_ac_cell]
+unpack_ac_node = utp.nodes[unpack_ac_cell]
 
 # ╔═╡ d011ab60-c791-43e4-babc-675be0a8b709
 # true (but should not be part of the test suite)
 unpack_ac_node.definitions == Set([:a, :c])
 
+# ╔═╡ 79d78476-d048-4b1a-8e55-5c978697bff8
+unpack_ac_code = utp.codes[unpack_ac_cell]
+
+# ╔═╡ bde5735f-1fd0-4298-8e12-5fd4eced5b48
+EEE.pretransform_pluto(unpack_ac_code.parsedcode)
+
 # ╔═╡ Cell order:
 # ╠═51df9d39-7d35-49e1-bac3-7354882bb141
 # ╠═67aa154f-a294-41ce-aea5-36cf5ddcf1de
 # ╠═ef466826-81b7-4f9d-a0e8-f48f0dc63d2f
+# ╠═5d55d8df-ba97-4ebc-9d96-35ff9cd11bd4
 # ╠═640d5a61-0e23-4614-96d7-6d79e015eee3
 # ╠═9f58ade4-c81b-45fb-a497-4f7503b94e13
 # ╠═63066171-c4e6-46e6-8e63-eb50f6c70ed1
+# ╠═6fc87b31-9206-4ccc-87a6-ad37b0d25415
 # ╠═88334e90-1486-40e2-84d5-8f49eda045fe
 # ╠═d5a36c7c-95bf-4bd3-96d7-1b2392eeec94
 # ╠═f3ee4c34-3c96-4254-aa07-34d67efaedc3
+# ╠═155b072a-d32f-4062-ad4e-1ab9792614ae
 # ╠═8411b188-54d9-43fd-9d47-6bd6d7f5ed86
 # ╠═53c808e9-a4bc-4fbc-b186-41532f54e7f8
 # ╠═21f86448-721a-4ffe-a098-1482071de585
@@ -92,3 +113,5 @@ unpack_ac_node.definitions == Set([:a, :c])
 # ╠═198d4900-9ae1-456f-b1cf-3c26a2d8249a
 # ╠═1f19f8ec-46e5-48d7-a557-15db25bc12ff
 # ╠═d011ab60-c791-43e4-babc-675be0a8b709
+# ╠═79d78476-d048-4b1a-8e55-5c978697bff8
+# ╠═bde5735f-1fd0-4298-8e12-5fd4eced5b48

--- a/test/notebooks/extract_from_source_usings.jl
+++ b/test/notebooks/extract_from_source_usings.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.22
+# v0.20.8
 
 using Markdown
 using InteractiveUtils
@@ -40,11 +40,11 @@ md"""
 md"## Just one variable"
 
 # ╔═╡ f3ee4c34-3c96-4254-aa07-34d67efaedc3
-nb = load_nb_with_topology(source_nb_file)
+utp = load_updated_topology(source_nb_file)
 
 # ╔═╡ 525f5fcc-efd1-48ef-8aeb-9c184e54a50d
 @nb_extract(
-	nb,
+	utp,
 	function fun_out_d_direct()
 		return d_direct
 	end
@@ -64,7 +64,7 @@ md"## Indirect with two inputs"
 
 # ╔═╡ 75b6aae9-e013-4b6c-ac88-721e77822c97
 @nb_extract(
-	nb,
+	utp,
 	function fun_v1_v2_out_d_indirect(v1, v2)
 		return d_indirect
 	end

--- a/test/notebooks/helpers.jl
+++ b/test/notebooks/helpers.jl
@@ -1,0 +1,97 @@
+### A Pluto.jl notebook ###
+# v0.20.8
+
+using Markdown
+using InteractiveUtils
+
+# ╔═╡ 51df9d39-7d35-49e1-bac3-7354882bb141
+import Pkg
+
+# ╔═╡ 67aa154f-a294-41ce-aea5-36cf5ddcf1de
+# ╠═╡ skip_as_script = true
+#=╠═╡
+begin
+	Pkg.activate(Base.current_project())
+	using Revise  # just to be sure Revise is called first (is it necessary ?)
+end
+  ╠═╡ =#
+
+# ╔═╡ acaf0efa-c78f-469a-b5dd-4a2c6f3cbabf
+using MacroTools
+
+# ╔═╡ 640d5a61-0e23-4614-96d7-6d79e015eee3
+using PlutoExtractors
+
+# ╔═╡ 9f58ade4-c81b-45fb-a497-4f7503b94e13
+import PlutoTest
+
+# ╔═╡ 88334e90-1486-40e2-84d5-8f49eda045fe
+root_dir = pkgdir(PlutoExtractors)
+
+# ╔═╡ d5a36c7c-95bf-4bd3-96d7-1b2392eeec94
+source_nb_file = joinpath(root_dir, "test", "notebooks", "source_types.jl")
+
+# ╔═╡ 8411b188-54d9-43fd-9d47-6bd6d7f5ed86
+md"""
+# Tests
+"""
+
+# ╔═╡ f3ee4c34-3c96-4254-aa07-34d67efaedc3
+utp = load_updated_topology(source_nb_file)
+
+# ╔═╡ e7ea8a83-7b0f-4479-921d-fdc9ac80218a
+template = :(
+	function fun_1()
+		return b
+	end
+)
+
+# ╔═╡ 6f45c8aa-557c-4e08-8669-40029b60497e
+(
+	template_dict,
+	given_symbols,
+	needed_symbols
+) = PlutoExtractors.template_analysis(template)
+
+# ╔═╡ b5e5cf07-df5b-4edd-9ef1-6ab38081133d
+# like `gensym(:PlutoExtractors)`, but fixed
+# Safe here, since there are no evaluations in this notebook.
+module_sym = Symbol("##PlutoExtractors#337")
+
+# ╔═╡ 847893f3-a0a6-4d09-a30c-9004b833b65c
+fun_wrapper_expr = PlutoExtractors.fun_wrapper(
+	template_dict,
+	module_sym
+)
+
+# ╔═╡ d140e98b-721b-41e4-9d2d-5cd4db1b981d
+# rm_all_lines, otherwise the LineNumberNodes would create differences
+expected_fun_wrapper_expr = PlutoExtractors.rm_all_lines(
+	:(function fun_1(; )
+		(var"##PlutoExtractors#337").fun_1(; )
+	end)
+)
+
+# ╔═╡ 61ded599-db04-43a5-a01a-ebf5892eef2b
+PlutoTest.@test fun_wrapper_expr == expected_fun_wrapper_expr
+
+# ╔═╡ 94b0b7e1-0a51-4cbd-92a1-ca8db5721312
+header_expr = PlutoExtractors.gather_header(utp, [])
+
+# ╔═╡ Cell order:
+# ╠═51df9d39-7d35-49e1-bac3-7354882bb141
+# ╠═67aa154f-a294-41ce-aea5-36cf5ddcf1de
+# ╠═acaf0efa-c78f-469a-b5dd-4a2c6f3cbabf
+# ╠═640d5a61-0e23-4614-96d7-6d79e015eee3
+# ╠═9f58ade4-c81b-45fb-a497-4f7503b94e13
+# ╠═88334e90-1486-40e2-84d5-8f49eda045fe
+# ╠═d5a36c7c-95bf-4bd3-96d7-1b2392eeec94
+# ╠═8411b188-54d9-43fd-9d47-6bd6d7f5ed86
+# ╠═f3ee4c34-3c96-4254-aa07-34d67efaedc3
+# ╠═e7ea8a83-7b0f-4479-921d-fdc9ac80218a
+# ╠═6f45c8aa-557c-4e08-8669-40029b60497e
+# ╠═b5e5cf07-df5b-4edd-9ef1-6ab38081133d
+# ╠═847893f3-a0a6-4d09-a30c-9004b833b65c
+# ╠═d140e98b-721b-41e4-9d2d-5cd4db1b981d
+# ╠═61ded599-db04-43a5-a01a-ebf5892eef2b
+# ╠═94b0b7e1-0a51-4cbd-92a1-ca8db5721312

--- a/test/notebooks/helpers.jl
+++ b/test/notebooks/helpers.jl
@@ -76,7 +76,7 @@ expected_fun_wrapper_expr = PlutoExtractors.rm_all_lines(
 PlutoTest.@test fun_wrapper_expr == expected_fun_wrapper_expr
 
 # ╔═╡ 94b0b7e1-0a51-4cbd-92a1-ca8db5721312
-header_expr = PlutoExtractors.gather_header(utp, [])
+header_expr = PlutoExtractors.collect_header_expressions(utp, [])
 
 # ╔═╡ Cell order:
 # ╠═51df9d39-7d35-49e1-bac3-7354882bb141

--- a/test/notebooks/helpers.jl
+++ b/test/notebooks/helpers.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.20.8
+# v0.20.10
 
 using Markdown
 using InteractiveUtils
@@ -53,6 +53,13 @@ template = :(
 	needed_symbols
 ) = PlutoExtractors.template_analysis(template)
 
+# ╔═╡ 1925349c-4afc-4d28-813c-9730e724d240
+# Sets have unique elements. Not sure this is mandatory, but it feels safer.
+PlutoTest.@test given_symbols isa Set
+
+# ╔═╡ 847ee1f7-0687-467a-9101-ab37c650986e
+PlutoTest.@test needed_symbols isa Set
+
 # ╔═╡ b5e5cf07-df5b-4edd-9ef1-6ab38081133d
 # like `gensym(:PlutoExtractors)`, but fixed
 # Safe here, since there are no evaluations in this notebook.
@@ -90,6 +97,8 @@ header_expr = PlutoExtractors.collect_header_expressions(utp, [])
 # ╠═f3ee4c34-3c96-4254-aa07-34d67efaedc3
 # ╠═e7ea8a83-7b0f-4479-921d-fdc9ac80218a
 # ╠═6f45c8aa-557c-4e08-8669-40029b60497e
+# ╠═1925349c-4afc-4d28-813c-9730e724d240
+# ╠═847ee1f7-0687-467a-9101-ab37c650986e
 # ╠═b5e5cf07-df5b-4edd-9ef1-6ab38081133d
 # ╠═847893f3-a0a6-4d09-a30c-9004b833b65c
 # ╠═d140e98b-721b-41e4-9d2d-5cd4db1b981d

--- a/test/notebooks/helpers.jl
+++ b/test/notebooks/helpers.jl
@@ -25,6 +25,9 @@ using PlutoExtractors
 # ╔═╡ 9f58ade4-c81b-45fb-a497-4f7503b94e13
 import PlutoTest
 
+# ╔═╡ a9193549-5d53-4d13-b0c5-3648c9357afe
+import PlutoDependencyExplorer as PDE
+
 # ╔═╡ 88334e90-1486-40e2-84d5-8f49eda045fe
 root_dir = pkgdir(PlutoExtractors)
 
@@ -85,12 +88,31 @@ PlutoTest.@test fun_wrapper_expr == expected_fun_wrapper_expr
 # ╔═╡ 94b0b7e1-0a51-4cbd-92a1-ca8db5721312
 header_expr = PlutoExtractors.collect_header_expressions(utp, [])
 
+# ╔═╡ fb850d61-5795-4424-bcd2-7ae811d98c92
+tpo = PDE.topological_order(utp)
+
+# ╔═╡ bc7ebc67-cb09-4043-9ba1-d5786b183cd3
+function is_sorted_in(cells, tpo::PDE.TopologicalOrder)
+	issorted(indexin(cells, tpo.runnable))
+end
+
+# ╔═╡ 1f903163-f9f1-4d11-a57f-d67c88970d1c
+needed_cells = PlutoExtractors.all_needed_cells(
+	utp,
+	given_symbols,
+	needed_symbols
+)
+
+# ╔═╡ 6f71127e-a15c-4ec9-a6b7-d7016d52e390
+PlutoTest.@test is_sorted_in(needed_cells, tpo)
+
 # ╔═╡ Cell order:
 # ╠═51df9d39-7d35-49e1-bac3-7354882bb141
 # ╠═67aa154f-a294-41ce-aea5-36cf5ddcf1de
 # ╠═acaf0efa-c78f-469a-b5dd-4a2c6f3cbabf
 # ╠═640d5a61-0e23-4614-96d7-6d79e015eee3
 # ╠═9f58ade4-c81b-45fb-a497-4f7503b94e13
+# ╠═a9193549-5d53-4d13-b0c5-3648c9357afe
 # ╠═88334e90-1486-40e2-84d5-8f49eda045fe
 # ╠═d5a36c7c-95bf-4bd3-96d7-1b2392eeec94
 # ╠═8411b188-54d9-43fd-9d47-6bd6d7f5ed86
@@ -104,3 +126,7 @@ header_expr = PlutoExtractors.collect_header_expressions(utp, [])
 # ╠═d140e98b-721b-41e4-9d2d-5cd4db1b981d
 # ╠═61ded599-db04-43a5-a01a-ebf5892eef2b
 # ╠═94b0b7e1-0a51-4cbd-92a1-ca8db5721312
+# ╠═fb850d61-5795-4424-bcd2-7ae811d98c92
+# ╠═bc7ebc67-cb09-4043-9ba1-d5786b183cd3
+# ╠═1f903163-f9f1-4d11-a57f-d67c88970d1c
+# ╠═6f71127e-a15c-4ec9-a6b7-d7016d52e390

--- a/test/notebooks/source_bind.jl
+++ b/test/notebooks/source_bind.jl
@@ -1,0 +1,40 @@
+### A Pluto.jl notebook ###
+# v0.20.8
+
+using Markdown
+using InteractiveUtils
+
+# This Pluto notebook uses @bind for interactivity. When running this notebook outside of Pluto, the following 'mock version' of @bind gives bound variables a default value (instead of an error).
+macro bind(def, element)
+    #! format: off
+    return quote
+        local iv = try Base.loaded_modules[Base.PkgId(Base.UUID("6e696c72-6542-2067-7265-42206c756150"), "AbstractPlutoDingetjes")].Bonds.initial_value catch; b -> missing; end
+        local el = $(esc(element))
+        global $(esc(def)) = Core.applicable(Base.get, el) ? Base.get(el) : iv(el)
+        el
+    end
+    #! format: on
+end
+
+# ╔═╡ 52a54f2e-33f7-45f0-b251-59c476c17994
+import Pkg
+
+# ╔═╡ a1be466e-5d31-4024-8c05-6afd5ede7840
+# avoid julia version clashes during testing
+Pkg.activate(Base.current_project())
+
+# ╔═╡ 3c5861f7-9ee8-4bc9-9bef-0cf961e009c1
+using PlutoUI
+
+# ╔═╡ 52ae84f7-d232-4e2c-9b56-e4a270c995f7
+@bind a PlutoUI.Slider(1:5; default = 3, show_value = true)
+
+# ╔═╡ 2c2a73dc-a60a-46b4-89f2-84656445a4f5
+b = 2a
+
+# ╔═╡ Cell order:
+# ╠═52a54f2e-33f7-45f0-b251-59c476c17994
+# ╠═a1be466e-5d31-4024-8c05-6afd5ede7840
+# ╠═3c5861f7-9ee8-4bc9-9bef-0cf961e009c1
+# ╠═52ae84f7-d232-4e2c-9b56-e4a270c995f7
+# ╠═2c2a73dc-a60a-46b4-89f2-84656445a4f5

--- a/test/notebooks/source_bind.jl
+++ b/test/notebooks/source_bind.jl
@@ -32,9 +32,25 @@ using PlutoUI
 # ╔═╡ 2c2a73dc-a60a-46b4-89f2-84656445a4f5
 b = 2a
 
+# ╔═╡ 7b792265-63a8-4f11-a782-97950356118a
+@bind c PlutoUI.Slider(1:5; default = 5, show_value = true)
+
+# ╔═╡ f002a445-02c5-4c38-b602-2e43279eaf45
+d = 5
+
+# ╔═╡ 6e1462cb-ac4c-4674-a2f0-1d861adf62ea
+se = @bind xe PlutoUI.Slider(1:10; default = 6, show_value = true)
+
+# ╔═╡ 27a89450-7f86-4604-99cd-d2b7cba94d0c
+
+
 # ╔═╡ Cell order:
 # ╠═52a54f2e-33f7-45f0-b251-59c476c17994
 # ╠═a1be466e-5d31-4024-8c05-6afd5ede7840
 # ╠═3c5861f7-9ee8-4bc9-9bef-0cf961e009c1
 # ╠═52ae84f7-d232-4e2c-9b56-e4a270c995f7
 # ╠═2c2a73dc-a60a-46b4-89f2-84656445a4f5
+# ╠═7b792265-63a8-4f11-a782-97950356118a
+# ╠═f002a445-02c5-4c38-b602-2e43279eaf45
+# ╠═6e1462cb-ac4c-4674-a2f0-1d861adf62ea
+# ╠═27a89450-7f86-4604-99cd-d2b7cba94d0c

--- a/test/notebooks/source_callables.jl
+++ b/test/notebooks/source_callables.jl
@@ -1,0 +1,170 @@
+### A Pluto.jl notebook ###
+# v0.20.8
+
+using Markdown
+using InteractiveUtils
+
+# ╔═╡ a9d0dc94-7c75-431a-b25d-7d89d2a3a9be
+import Pkg
+
+# ╔═╡ 89e763c1-1a08-4b40-9fbf-b03b400ead5d
+# avoid julia version clashes during testing
+Pkg.activate(Base.current_project())
+
+# ╔═╡ 03c7b89c-0797-454a-984e-d096de6acacf
+md"""
+# Data
+"""
+
+# ╔═╡ 57aa982b-8cf7-4e00-b9f7-44f48a57a3e0
+a = 2
+
+# ╔═╡ 9df142ea-cf46-4e08-ac9b-c27163d3d1ae
+md"""
+# Function
+"""
+
+# ╔═╡ 4a2e6cb9-fee8-43f7-b228-ad3daf3020d1
+md"""
+## Without global
+"""
+
+# ╔═╡ c5b084df-8141-4f0e-8326-0374d574bab7
+fun_short(x) = x^2
+
+# ╔═╡ a8528330-3f1a-4708-9576-327d55d33640
+b = fun_short(a)
+
+# ╔═╡ c6d9849b-d704-4aab-b315-cc82957fd874
+function fun_long(x)
+	x^3
+end
+
+# ╔═╡ d95c30ec-260c-4bfe-b418-002cba4587d8
+c = fun_long(b)
+
+# ╔═╡ 12c92a4a-ef97-45ad-a8c5-6bb17734be60
+function fun_fun_long(x)
+	fun_long(x)
+end
+
+# ╔═╡ d858d299-a94c-4c01-932d-80d8b0c7d205
+d = fun_fun_long(b)
+
+# ╔═╡ 7a94736e-0513-4ebd-b5b5-e04c6266f965
+md"""
+## With global
+"""
+
+# ╔═╡ 419d6b53-101b-4056-a8a5-c68d39f8cdf2
+md"""
+### Simple
+"""
+
+# ╔═╡ 93f72410-5b8f-4f42-a861-18af5fa7ce2c
+fun_capt_a() = a
+
+# ╔═╡ 48f418ec-0a3a-457a-9984-0c003404a429
+fun_capt_a()
+
+# ╔═╡ 2517df0b-0018-41d3-9663-dec7345c0514
+fun_capt_a_b() = a + b
+
+# ╔═╡ 6a6801f3-9822-4772-ad36-14a30e0e8b8f
+fun_capt_a_b()
+
+# ╔═╡ 5c3890ea-9f48-4730-9de7-4ecfa739901d
+md"""
+### Chain
+"""
+
+# ╔═╡ 9239722f-49f5-4eaa-989e-53016d224f87
+fun_chain() = fun_capt_a()
+
+# ╔═╡ db49d6e8-0ea5-4fb1-a570-f90076a72fc9
+md"""
+# Callable Struct
+
+https://docs.julialang.org/en/v1/manual/methods/#Function-like-objects
+"""
+
+# ╔═╡ 92d272d3-8572-4638-a8ec-d19310fd6a6d
+md"""
+## Without any global
+"""
+
+# ╔═╡ 356e0ffa-55d9-47f9-bf00-fe69132c9a05
+# Need a begin...end block, cf. https://github.com/fonsp/Pluto.jl/issues/7
+begin
+struct Scaler{F}
+	factor::F
+end
+(sc::Scaler)(x) = x * sc.factor
+end
+
+# ╔═╡ 7574fcd2-ff3d-44d3-9811-6654e63e3f14
+sc = Scaler(3.0)
+
+# ╔═╡ 1f3bd476-16eb-44d6-a621-0cba7e729b7f
+x = 4.0
+
+# ╔═╡ a1208157-a3f3-4c73-adec-450c1e95712c
+scaled_x = sc(x)  # should be 12.0
+
+# ╔═╡ f40af99e-a4e0-4349-9345-328b4711c6fb
+md"""
+## With global
+"""
+
+# ╔═╡ 7dec8a20-0c48-4957-8344-3846ace9c15c
+# global, notebook-wise
+offset = 6.0
+
+# ╔═╡ bd646149-b7e6-49af-b6be-f18476394eae
+# Need a begin...end block, cf. https://github.com/fonsp/Pluto.jl/issues/7
+begin
+struct Scaler2{F}
+	factor::F
+end
+# note the use of the global offset (unclean, but may happen)
+(sc::Scaler2)(x) = x * sc.factor + offset
+end
+
+# ╔═╡ 93496e06-680c-424a-9320-bbcf7613b1c6
+sc_2 = Scaler2(3.0)
+
+# ╔═╡ 2a0ac8d5-4085-48aa-8d6c-7cde042a4260
+scaled_x_2 = sc_2(x)
+
+# ╔═╡ Cell order:
+# ╠═a9d0dc94-7c75-431a-b25d-7d89d2a3a9be
+# ╠═89e763c1-1a08-4b40-9fbf-b03b400ead5d
+# ╠═03c7b89c-0797-454a-984e-d096de6acacf
+# ╠═57aa982b-8cf7-4e00-b9f7-44f48a57a3e0
+# ╠═9df142ea-cf46-4e08-ac9b-c27163d3d1ae
+# ╠═4a2e6cb9-fee8-43f7-b228-ad3daf3020d1
+# ╠═c5b084df-8141-4f0e-8326-0374d574bab7
+# ╠═a8528330-3f1a-4708-9576-327d55d33640
+# ╠═c6d9849b-d704-4aab-b315-cc82957fd874
+# ╠═d95c30ec-260c-4bfe-b418-002cba4587d8
+# ╠═12c92a4a-ef97-45ad-a8c5-6bb17734be60
+# ╠═d858d299-a94c-4c01-932d-80d8b0c7d205
+# ╠═7a94736e-0513-4ebd-b5b5-e04c6266f965
+# ╠═419d6b53-101b-4056-a8a5-c68d39f8cdf2
+# ╠═93f72410-5b8f-4f42-a861-18af5fa7ce2c
+# ╠═48f418ec-0a3a-457a-9984-0c003404a429
+# ╠═2517df0b-0018-41d3-9663-dec7345c0514
+# ╠═6a6801f3-9822-4772-ad36-14a30e0e8b8f
+# ╠═5c3890ea-9f48-4730-9de7-4ecfa739901d
+# ╠═9239722f-49f5-4eaa-989e-53016d224f87
+# ╠═db49d6e8-0ea5-4fb1-a570-f90076a72fc9
+# ╠═92d272d3-8572-4638-a8ec-d19310fd6a6d
+# ╠═356e0ffa-55d9-47f9-bf00-fe69132c9a05
+# ╠═7574fcd2-ff3d-44d3-9811-6654e63e3f14
+# ╠═1f3bd476-16eb-44d6-a621-0cba7e729b7f
+# ╠═a1208157-a3f3-4c73-adec-450c1e95712c
+# ╠═f40af99e-a4e0-4349-9345-328b4711c6fb
+# ╠═7dec8a20-0c48-4957-8344-3846ace9c15c
+# ╠═bd646149-b7e6-49af-b6be-f18476394eae
+# ╠═93496e06-680c-424a-9320-bbcf7613b1c6
+# ╠═2a0ac8d5-4085-48aa-8d6c-7cde042a4260

--- a/test/notebooks/source_markdown.jl
+++ b/test/notebooks/source_markdown.jl
@@ -1,0 +1,32 @@
+### A Pluto.jl notebook ###
+# v0.20.8
+
+using Markdown
+using InteractiveUtils
+
+# ╔═╡ 52a54f2e-33f7-45f0-b251-59c476c17994
+import Pkg
+
+# ╔═╡ a1be466e-5d31-4024-8c05-6afd5ede7840
+# avoid julia version clashes during testing
+Pkg.activate(Base.current_project())
+
+# ╔═╡ d76267bc-917e-42a0-8576-33a0a84ad8e3
+md"""
+# Notebook with markdown
+
+Pluto allow markdown without any `using Markdown`.
+"""
+
+# ╔═╡ 52ae84f7-d232-4e2c-9b56-e4a270c995f7
+a = 1
+
+# ╔═╡ 2c2a73dc-a60a-46b4-89f2-84656445a4f5
+b = 2a
+
+# ╔═╡ Cell order:
+# ╠═52a54f2e-33f7-45f0-b251-59c476c17994
+# ╠═a1be466e-5d31-4024-8c05-6afd5ede7840
+# ╠═d76267bc-917e-42a0-8576-33a0a84ad8e3
+# ╠═52ae84f7-d232-4e2c-9b56-e4a270c995f7
+# ╠═2c2a73dc-a60a-46b4-89f2-84656445a4f5

--- a/test/notebooks/source_semicolon.jl
+++ b/test/notebooks/source_semicolon.jl
@@ -1,0 +1,30 @@
+### A Pluto.jl notebook ###
+# v0.20.8
+
+using Markdown
+using InteractiveUtils
+
+# ╔═╡ 588ca7b5-0be6-42b1-95ef-850754832ad8
+import Pkg
+
+# ╔═╡ d54f6eae-833b-4337-bff7-c0e851b4b5af
+# ╠═╡ skip_as_script = true
+#=╠═╡
+Pkg.activate(Base.current_project())
+  ╠═╡ =#
+
+# ╔═╡ 5460ab14-ea6f-11ec-083c-339d0912f969
+a = 1
+
+# ╔═╡ 1b45d930-ffb8-48b1-974e-29e3257e0633
+b = 2a;
+
+# ╔═╡ 73585a4f-c88d-4221-bae9-dbd7e1f927e5
+c = 2b
+
+# ╔═╡ Cell order:
+# ╠═588ca7b5-0be6-42b1-95ef-850754832ad8
+# ╠═d54f6eae-833b-4337-bff7-c0e851b4b5af
+# ╠═5460ab14-ea6f-11ec-083c-339d0912f969
+# ╠═1b45d930-ffb8-48b1-974e-29e3257e0633
+# ╠═73585a4f-c88d-4221-bae9-dbd7e1f927e5

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,6 +42,11 @@ server_session.connected_clients[fakeclient.id] = fakeclient
 	@testset "Extract from source_types.jl" begin
 		include("notebooks/extract_from_source_types.jl")
 	end
+
+	# Test functions and callable structs => after types
+	@testset "Extract from source_functions.jl" begin
+		include("notebooks/extract_from_source_callables.jl")
+	end
 	
 	@testset "Extract from source_unpack.jl" begin
 		include("notebooks/extract_from_source_unpack.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,4 +46,8 @@ server_session.connected_clients[fakeclient.id] = fakeclient
 	@testset "Extract from source_unpack.jl" begin
 		include("notebooks/extract_from_source_unpack.jl")
 	end
+	
+	@testset "Extract from source_markdown.jl" begin
+		include("notebooks/extract_from_source_markdown.jl")
+	end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,10 @@ server_session.connected_clients[fakeclient.id] = fakeclient
 	    include("try.jl")
 	end
 
+	@testset "Helpers" begin
+		include("notebooks/helpers.jl")
+	end
+
 	@testset "Extract from source_basic.jl" begin
 		include("notebooks/extract_from_source_basic.jl")
 	end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,10 +23,6 @@ server_session.connected_clients[fakeclient.id] = fakeclient
 
 
 @testset "PlutoExtractors.jl" begin
-	@testset "try" begin
-	    include("try.jl")
-	end
-
 	@testset "Helpers" begin
 		include("notebooks/helpers.jl")
 	end
@@ -57,5 +53,9 @@ server_session.connected_clients[fakeclient.id] = fakeclient
 	
 	@testset "Extract from source_bind.jl" begin
 		include("notebooks/extract_from_source_bind.jl")
+	end
+
+	@testset "Live" begin
+	    include("live.jl")
 	end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,4 +50,8 @@ server_session.connected_clients[fakeclient.id] = fakeclient
 	@testset "Extract from source_markdown.jl" begin
 		include("notebooks/extract_from_source_markdown.jl")
 	end
+	
+	@testset "Extract from source_bind.jl" begin
+		include("notebooks/extract_from_source_bind.jl")
+	end
 end

--- a/test/try.jl
+++ b/test/try.jl
@@ -7,9 +7,9 @@
 	# "# expected" cells produce an output that the next cell should reproduce
 	dest_notebook = Pluto.Notebook([
 		Pluto.Cell("""using PlutoExtractors"""),
-		Pluto.Cell("""nb = load_nb_with_topology("$(source_basic_path)")"""),
+		Pluto.Cell("""utp = load_updated_topology("$(source_basic_path)")"""),
 		Pluto.Cell("""
-			@nb_extract(nb, 
+			@nb_extract(utp, 
 				function fun(a)
 					return c
 				end


### PR DESCRIPTION
Leverage the new ExpressionExplorer and PlutoDependencyExplorer,
and put everything in a module.
The source notebook no longer needs to be run to get the function.
And #11 is fixed.
