### PR TITLE
Prepend const to assignments in module

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoExtractors"
 uuid = "25cc9095-8c7a-4c84-8905-c5de52e7766c"
 authors = ["ederag <edera@gmx.fr> and contributors"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoExtractors"
 uuid = "25cc9095-8c7a-4c84-8905-c5de52e7766c"
 authors = ["ederag <edera@gmx.fr> and contributors"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/benchmark/notebooks/bm_assignments.jl
+++ b/benchmark/notebooks/bm_assignments.jl
@@ -1,0 +1,150 @@
+### A Pluto.jl notebook ###
+# v0.20.13
+
+using Markdown
+using InteractiveUtils
+
+# ╔═╡ 51df9d39-7d35-49e1-bac3-7354882bb141
+import Pkg
+
+# ╔═╡ 67aa154f-a294-41ce-aea5-36cf5ddcf1de
+# ╠═╡ skip_as_script = true
+#=╠═╡
+begin
+	Pkg.activate(Base.current_project())
+	using Revise  # just to be sure Revise is called first (is it necessary ?)
+end
+  ╠═╡ =#
+
+# ╔═╡ 57b17b5e-7c93-4d15-b5b9-033fd49e2998
+using BenchmarkTools
+
+# ╔═╡ 640d5a61-0e23-4614-96d7-6d79e015eee3
+using PlutoExtractors
+
+# ╔═╡ 9f58ade4-c81b-45fb-a497-4f7503b94e13
+import PlutoTest
+
+# ╔═╡ 88334e90-1486-40e2-84d5-8f49eda045fe
+root_dir = pkgdir(PlutoExtractors)
+
+# ╔═╡ 3c63d43c-e2ee-4d18-8755-4809016e0fe4
+# https://discourse.julialang.org/t/pluto-get-current-notebook-file-path/60543/3
+notebookpath() = replace(@__FILE__, r"#==#.*" => "")
+
+# ╔═╡ d5a36c7c-95bf-4bd3-96d7-1b2392eeec94
+# Self-sourced, do not create cycles !
+source_nb_file = notebookpath()
+
+# ╔═╡ f3ee4c34-3c96-4254-aa07-34d67efaedc3
+utp = load_updated_topology(source_nb_file)
+
+# ╔═╡ 2a76c938-34a3-4539-9487-c691e16e69f8
+md"""
+# Definitions
+"""
+
+# ╔═╡ 88294f24-4876-4692-858b-c28c50986dea
+a = 1
+
+# ╔═╡ f158c8de-3769-4e18-97e2-dfcc841f9306
+b= 2a
+
+# ╔═╡ e190e2a5-48fa-4f7f-be65-35907b169931
+begin
+	c = a
+	d = 3b
+end
+
+# ╔═╡ 8411b188-54d9-43fd-9d47-6bd6d7f5ed86
+md"""
+# Benchmarks
+"""
+
+# ╔═╡ e4837658-a2ef-4dfa-8cb0-f909eac426b6
+md"""
+## Basic
+"""
+
+# ╔═╡ 525f5fcc-efd1-48ef-8aeb-9c184e54a50d
+@nb_extract(
+	utp,
+	function fun_1(a)
+		return b
+	end
+)
+
+# ╔═╡ 22e1fc30-77ae-49eb-8e06-b17610980322
+PlutoTest.@test fun_1(2) == 4
+
+# ╔═╡ 2e593068-b7cb-4a4c-be06-cb9540ee265f
+@benchmark fun_1(x)  setup = (x = rand())
+
+# ╔═╡ b92d2962-cd0e-4f07-9f8e-03d4ee082c49
+md"""
+## From block
+"""
+
+# ╔═╡ cf58a703-4215-4fa4-962a-b01ba86042ed
+@nb_extract(
+	utp,
+	function fun_2(a)
+		return d
+	end
+)
+
+# ╔═╡ 446fb193-a336-4c3c-bf40-27b2aa7a19f8
+@benchmark fun_2(x)  setup = (x = rand())
+
+# ╔═╡ c0584984-4488-43dd-b2b8-396acabd3aaa
+@nb_extract(
+	utp,
+	function fun_3(a)
+		return sin(d)
+	end
+)
+
+# ╔═╡ a9df9618-e0fc-4039-b283-9e6a58c9b110
+# everything that depends on :a gets into the :function,
+# so this should not allocate "naturally"
+@benchmark fun_3(x)  setup = (x = rand())
+
+# ╔═╡ 2566d59a-42e5-488d-aa13-8bafaf1ad13d
+@nb_extract(
+	utp,
+	function fun_4()
+		return sin(d)
+	end
+)
+
+# ╔═╡ 701eaa3b-748a-4e39-aafb-29d3482c871f
+# No argument at all => everything gets into the :module
+# this would allocate if :const were not prepended properly (PR #22)
+@benchmark fun_4()
+
+# ╔═╡ Cell order:
+# ╠═51df9d39-7d35-49e1-bac3-7354882bb141
+# ╠═67aa154f-a294-41ce-aea5-36cf5ddcf1de
+# ╠═57b17b5e-7c93-4d15-b5b9-033fd49e2998
+# ╠═640d5a61-0e23-4614-96d7-6d79e015eee3
+# ╠═9f58ade4-c81b-45fb-a497-4f7503b94e13
+# ╠═88334e90-1486-40e2-84d5-8f49eda045fe
+# ╠═3c63d43c-e2ee-4d18-8755-4809016e0fe4
+# ╠═d5a36c7c-95bf-4bd3-96d7-1b2392eeec94
+# ╠═f3ee4c34-3c96-4254-aa07-34d67efaedc3
+# ╠═2a76c938-34a3-4539-9487-c691e16e69f8
+# ╠═88294f24-4876-4692-858b-c28c50986dea
+# ╠═f158c8de-3769-4e18-97e2-dfcc841f9306
+# ╠═e190e2a5-48fa-4f7f-be65-35907b169931
+# ╠═8411b188-54d9-43fd-9d47-6bd6d7f5ed86
+# ╠═e4837658-a2ef-4dfa-8cb0-f909eac426b6
+# ╠═525f5fcc-efd1-48ef-8aeb-9c184e54a50d
+# ╠═22e1fc30-77ae-49eb-8e06-b17610980322
+# ╠═2e593068-b7cb-4a4c-be06-cb9540ee265f
+# ╠═b92d2962-cd0e-4f07-9f8e-03d4ee082c49
+# ╠═cf58a703-4215-4fa4-962a-b01ba86042ed
+# ╠═446fb193-a336-4c3c-bf40-27b2aa7a19f8
+# ╠═c0584984-4488-43dd-b2b8-396acabd3aaa
+# ╠═a9df9618-e0fc-4039-b283-9e6a58c9b110
+# ╠═2566d59a-42e5-488d-aa13-8bafaf1ad13d
+# ╠═701eaa3b-748a-4e39-aafb-29d3482c871f

--- a/benchmark/notebooks/bm_callables.jl
+++ b/benchmark/notebooks/bm_callables.jl
@@ -1,0 +1,205 @@
+### A Pluto.jl notebook ###
+# v0.20.13
+
+using Markdown
+using InteractiveUtils
+
+# ╔═╡ 51df9d39-7d35-49e1-bac3-7354882bb141
+import Pkg
+
+# ╔═╡ 67aa154f-a294-41ce-aea5-36cf5ddcf1de
+# ╠═╡ skip_as_script = true
+#=╠═╡
+begin
+	Pkg.activate(Base.current_project())
+	using Revise  # just to be sure Revise is called first (is it necessary ?)
+end
+  ╠═╡ =#
+
+# ╔═╡ 57b17b5e-7c93-4d15-b5b9-033fd49e2998
+using BenchmarkTools
+
+# ╔═╡ 640d5a61-0e23-4614-96d7-6d79e015eee3
+using PlutoExtractors
+
+# ╔═╡ 9f58ade4-c81b-45fb-a497-4f7503b94e13
+import PlutoTest
+
+# ╔═╡ 88334e90-1486-40e2-84d5-8f49eda045fe
+root_dir = pkgdir(PlutoExtractors)
+
+# ╔═╡ d5a36c7c-95bf-4bd3-96d7-1b2392eeec94
+source_nb_file = joinpath(root_dir, "test", "notebooks", "source_callables.jl")
+
+# ╔═╡ f3ee4c34-3c96-4254-aa07-34d67efaedc3
+utp = load_updated_topology(source_nb_file)
+
+# ╔═╡ 8411b188-54d9-43fd-9d47-6bd6d7f5ed86
+md"""
+# Tests
+"""
+
+# ╔═╡ e4837658-a2ef-4dfa-8cb0-f909eac426b6
+md"""
+## Without global
+"""
+
+# ╔═╡ 525f5fcc-efd1-48ef-8aeb-9c184e54a50d
+@nb_extract(
+	utp,
+	function fun_1(x)
+		return scaled_x
+	end
+)
+
+# ╔═╡ 9cf1c8ea-6043-41cd-abdd-595ebf5254b2
+PlutoTest.@test fun_1(5.0) == 15.0
+
+# ╔═╡ b8cc866b-8dd3-434a-8ee9-f283e529490e
+@benchmark fun_1(x)  setup = (x = rand())
+
+# ╔═╡ 9768ce53-304b-4794-9de2-d09d6b39cf05
+md"""
+## With global
+"""
+
+# ╔═╡ 79059923-0737-40fb-80d9-5381bdece98a
+@nb_extract(
+	utp,
+	function fun_2(x)
+		return scaled_x_2
+	end
+)
+
+# ╔═╡ 5e4d4b3a-aa18-425e-bc31-cf5a87d8a196
+fun_2(3.0)
+
+# ╔═╡ 2701ad20-1c64-4446-8c74-946ff3f9f9cd
+@benchmark fun_2(x)  setup = (x = rand())
+
+# ╔═╡ 5419c947-011c-449c-ba24-479d43fc6d2c
+md"""
+## Functions
+"""
+
+# ╔═╡ ace85006-e9c4-43c3-a004-6f2b818afd49
+@nb_extract(
+	utp,
+	function fun_3(x)
+		return fun_fun_long(x)
+	end
+)
+
+# ╔═╡ ce8c6503-9475-4261-836a-61a0859b2cc6
+PlutoTest.@test fun_3(3) == 27
+
+# ╔═╡ 0316f703-5290-458c-9a6a-f8dd38578593
+@benchmark fun_3(x)  setup = (x = rand())
+
+# ╔═╡ 74986ddb-f85a-477b-b036-6a534ea65e56
+@nb_extract(
+	utp,
+	function fun_4()
+		return d
+	end
+)
+
+# ╔═╡ e925b852-cf7b-4545-8bd3-5c3b0cb2fde4
+PlutoTest.@test fun_4() == 64
+
+# ╔═╡ 401f1ab9-21f6-4900-9294-0b460c996e3d
+@benchmark fun_4()
+
+# ╔═╡ f255eb1a-9fc1-4dfa-812e-faaaa42ed666
+@nb_extract(
+	utp,
+	function fun_5()
+		return fun_capt_a()
+	end
+)
+
+# ╔═╡ fce2c7fb-f9be-45a7-9a46-211012ecae9d
+PlutoTest.@test fun_5() == 2
+
+# ╔═╡ 0ac829e6-d662-4774-9a62-305162ecc7c1
+@benchmark fun_5()
+
+# ╔═╡ 91f52bb6-036e-472f-98d5-8e5dedd236e6
+@nb_extract(
+	utp,
+	function fun_6(a)
+		return fun_capt_a()
+	end
+)
+
+# ╔═╡ c04f2ae1-60e7-4edd-9f66-6155eb8a34d6
+PlutoTest.@test fun_6(3) == 3
+
+# ╔═╡ d4a81a85-3d4f-4a5d-a77a-cc9b0444483a
+@benchmark fun_6(x)  setup = (x = rand())
+
+# ╔═╡ 52cd299d-7e5c-4342-aedb-81a55a5253b1
+@nb_extract(
+	utp,
+	function fun_7(b)
+		return fun_capt_a_b()
+	end
+)
+
+# ╔═╡ d5661bd4-6cfe-4a0f-a4a4-db60d5dd3c73
+PlutoTest.@test fun_7(3) == 5
+
+# ╔═╡ 15588f9f-909a-411d-ac71-b5ecdcdb951a
+@benchmark fun_7(x)  setup = (x = rand())
+
+# ╔═╡ 2386b27f-1c20-4884-9898-2acd57205e54
+@nb_extract(
+	utp,
+	function fun_8(a)
+		return fun_chain()
+	end
+)
+
+# ╔═╡ 99e54bbc-535b-4b5e-87b6-9df5fbebb3e2
+fun_8(2)
+
+# ╔═╡ 2e593068-b7cb-4a4c-be06-cb9540ee265f
+@benchmark fun_8(x)  setup = (x = rand())
+
+# ╔═╡ Cell order:
+# ╠═51df9d39-7d35-49e1-bac3-7354882bb141
+# ╠═67aa154f-a294-41ce-aea5-36cf5ddcf1de
+# ╠═57b17b5e-7c93-4d15-b5b9-033fd49e2998
+# ╠═640d5a61-0e23-4614-96d7-6d79e015eee3
+# ╠═9f58ade4-c81b-45fb-a497-4f7503b94e13
+# ╠═88334e90-1486-40e2-84d5-8f49eda045fe
+# ╠═d5a36c7c-95bf-4bd3-96d7-1b2392eeec94
+# ╠═f3ee4c34-3c96-4254-aa07-34d67efaedc3
+# ╠═8411b188-54d9-43fd-9d47-6bd6d7f5ed86
+# ╠═e4837658-a2ef-4dfa-8cb0-f909eac426b6
+# ╠═525f5fcc-efd1-48ef-8aeb-9c184e54a50d
+# ╠═9cf1c8ea-6043-41cd-abdd-595ebf5254b2
+# ╠═b8cc866b-8dd3-434a-8ee9-f283e529490e
+# ╠═9768ce53-304b-4794-9de2-d09d6b39cf05
+# ╠═79059923-0737-40fb-80d9-5381bdece98a
+# ╠═5e4d4b3a-aa18-425e-bc31-cf5a87d8a196
+# ╠═2701ad20-1c64-4446-8c74-946ff3f9f9cd
+# ╠═5419c947-011c-449c-ba24-479d43fc6d2c
+# ╠═ace85006-e9c4-43c3-a004-6f2b818afd49
+# ╠═ce8c6503-9475-4261-836a-61a0859b2cc6
+# ╠═0316f703-5290-458c-9a6a-f8dd38578593
+# ╠═74986ddb-f85a-477b-b036-6a534ea65e56
+# ╠═e925b852-cf7b-4545-8bd3-5c3b0cb2fde4
+# ╠═401f1ab9-21f6-4900-9294-0b460c996e3d
+# ╠═f255eb1a-9fc1-4dfa-812e-faaaa42ed666
+# ╠═fce2c7fb-f9be-45a7-9a46-211012ecae9d
+# ╠═0ac829e6-d662-4774-9a62-305162ecc7c1
+# ╠═91f52bb6-036e-472f-98d5-8e5dedd236e6
+# ╠═c04f2ae1-60e7-4edd-9f66-6155eb8a34d6
+# ╠═d4a81a85-3d4f-4a5d-a77a-cc9b0444483a
+# ╠═52cd299d-7e5c-4342-aedb-81a55a5253b1
+# ╠═d5661bd4-6cfe-4a0f-a4a4-db60d5dd3c73
+# ╠═15588f9f-909a-411d-ac71-b5ecdcdb951a
+# ╠═2386b27f-1c20-4884-9898-2acd57205e54
+# ╠═99e54bbc-535b-4b5e-87b6-9df5fbebb3e2
+# ╠═2e593068-b7cb-4a4c-be06-cb9540ee265f

--- a/src/notebooks/extractors.jl
+++ b/src/notebooks/extractors.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.20.10
+# v0.20.13
 
 #> [frontmatter]
 #> title = ""
@@ -455,6 +455,17 @@ function split_destinations(
 	needed_cells, destinations
 end
 
+# ╔═╡ 56254f07-abe3-4161-871a-f008db14a67a
+function tweak_expression(ex, destination::Symbol)
+	@assert destination in (:module, :function)
+	if destination == :module
+		if MacroTools.isexpr(ex, :(=))
+			ex = Expr(:const, ex)
+		end
+	end
+	ex
+end
+
 # ╔═╡ 58780697-0b89-420c-8b22-a31705ce45e4
 function nb_extractor_core(
 	utp,
@@ -483,9 +494,10 @@ function nb_extractor_core(
 		code_expr = Meta.parse(code_str)
 		check_safe_bind(code_expr, given_symbols)
 		# if not :function, than can be in the module toplevel by default
-		destination = get(destinations, cell, :default)
+		destination = get(destinations, cell, :module)
 		expressions = destination === :function ? body.args : module_expressions
-		push!(expressions, code_expr)
+		tweaked_expr = tweak_expression(code_expr, destination)
+		push!(expressions, tweaked_expr)
 	end
 	# get rid of const (not allowed in function body)
 	body = MacroTools.postwalk(body) do x
@@ -539,4 +551,5 @@ rm_all_lines(ex) = MacroTools.prewalk(MacroTools.rmlines, ex)
 # ╠═e4ecb782-85af-4e66-a7af-72eca79bd191
 # ╠═d2c81f1c-2756-4877-809f-5cc7b827ce9d
 # ╠═aaa4c1e6-bf01-4843-a168-1bd8b252f749
+# ╠═56254f07-abe3-4161-871a-f008db14a67a
 # ╠═20548484-991e-4b15-b6c5-8ea6b0bf69cb

--- a/src/notebooks/extractors.jl
+++ b/src/notebooks/extractors.jl
@@ -461,6 +461,8 @@ function tweak_expression(ex, destination::Symbol)
 	if destination == :module
 		if MacroTools.isexpr(ex, :(=))
 			ex = Expr(:const, ex)
+		elseif MacroTools.isexpr(ex, :block)
+			ex.args .= tweak_expression.(ex.args, destination)
 		end
 	else
 		# get rid of const (not allowed in function body)

--- a/src/notebooks/extractors.jl
+++ b/src/notebooks/extractors.jl
@@ -462,6 +462,11 @@ function tweak_expression(ex, destination::Symbol)
 		if MacroTools.isexpr(ex, :(=))
 			ex = Expr(:const, ex)
 		end
+	else
+		# get rid of const (not allowed in function body)
+		ex = MacroTools.postwalk(ex) do x
+			MacroTools.isexpr(x, :const) ? only(x.args) : x
+		end
 	end
 	ex
 end
@@ -498,10 +503,6 @@ function nb_extractor_core(
 		expressions = destination === :function ? body.args : module_expressions
 		tweaked_expr = tweak_expression(code_expr, destination)
 		push!(expressions, tweaked_expr)
-	end
-	# get rid of const (not allowed in function body)
-	body = MacroTools.postwalk(body) do x
-		MacroTools.isexpr(x, :const) ? only(x.args) : x
 	end
 
 	append!(body.args, template_body.args)

--- a/test/notebooks/extract_from_source_types.jl
+++ b/test/notebooks/extract_from_source_types.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.20.8
+# v0.20.13
 
 using Markdown
 using InteractiveUtils
@@ -79,6 +79,25 @@ Sensitive to [Julia#50354](https://github.com/JuliaLang/julia/issues/50354) ?
 # ╔═╡ 175535b1-9599-45e5-a428-8282f99ee50d
 PlutoTest.@test fun_2() === true
 
+# ╔═╡ 284fb76a-1ee0-4b3d-9c32-d6e27cf2d2dc
+md"""
+### Parametric type assignments
+"""
+
+# ╔═╡ f87071f9-f1a1-4801-9c38-6f2ccba20e1c
+@nb_extract(
+	utp,
+	function fun_3(x_1)
+		return res_1_2
+	end
+)
+
+# ╔═╡ 9fc8253e-0d81-4120-a8fa-051484ec2d53
+PlutoTest.@test fun_3(5.0) == 25.0
+
+# ╔═╡ dce0c2a7-3a3a-4565-ac3f-8d67f6874db3
+PlutoTest.@test isnan(fun_3(nothing))
+
 # ╔═╡ Cell order:
 # ╠═51df9d39-7d35-49e1-bac3-7354882bb141
 # ╠═67aa154f-a294-41ce-aea5-36cf5ddcf1de
@@ -96,3 +115,7 @@ PlutoTest.@test fun_2() === true
 # ╠═6f6178c8-9c47-4ccb-a8a6-bfb6ac79d30f
 # ╠═919bd4ba-6fe2-4641-b7b7-1c184f97679d
 # ╠═175535b1-9599-45e5-a428-8282f99ee50d
+# ╠═284fb76a-1ee0-4b3d-9c32-d6e27cf2d2dc
+# ╠═f87071f9-f1a1-4801-9c38-6f2ccba20e1c
+# ╠═9fc8253e-0d81-4120-a8fa-051484ec2d53
+# ╠═dce0c2a7-3a3a-4565-ac3f-8d67f6874db3

--- a/test/notebooks/helpers.jl
+++ b/test/notebooks/helpers.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.20.10
+# v0.20.13
 
 using Markdown
 using InteractiveUtils
@@ -21,6 +21,9 @@ using MacroTools
 
 # ╔═╡ 640d5a61-0e23-4614-96d7-6d79e015eee3
 using PlutoExtractors
+
+# ╔═╡ 9d8610c8-23d0-4ab8-bd8a-2dbe8548cf18
+using PlutoExtractors: rm_all_lines
 
 # ╔═╡ 9f58ade4-c81b-45fb-a497-4f7503b94e13
 import PlutoTest
@@ -106,11 +109,28 @@ needed_cells = PlutoExtractors.all_needed_cells(
 # ╔═╡ 6f71127e-a15c-4ec9-a6b7-d7016d52e390
 PlutoTest.@test is_sorted_in(needed_cells, tpo)
 
+# ╔═╡ 2a48c478-9906-4e4b-9487-03f80459ac9d
+PlutoTest.@test PlutoExtractors.tweak_expression(
+	:(
+		begin
+			a = 1
+			b = 2
+		end
+	),
+	:module
+) |> rm_all_lines == :(
+	begin
+		const a = 1
+		const b = 2
+	end
+) |> rm_all_lines
+
 # ╔═╡ Cell order:
 # ╠═51df9d39-7d35-49e1-bac3-7354882bb141
 # ╠═67aa154f-a294-41ce-aea5-36cf5ddcf1de
 # ╠═acaf0efa-c78f-469a-b5dd-4a2c6f3cbabf
 # ╠═640d5a61-0e23-4614-96d7-6d79e015eee3
+# ╠═9d8610c8-23d0-4ab8-bd8a-2dbe8548cf18
 # ╠═9f58ade4-c81b-45fb-a497-4f7503b94e13
 # ╠═a9193549-5d53-4d13-b0c5-3648c9357afe
 # ╠═88334e90-1486-40e2-84d5-8f49eda045fe
@@ -130,3 +150,4 @@ PlutoTest.@test is_sorted_in(needed_cells, tpo)
 # ╠═bc7ebc67-cb09-4043-9ba1-d5786b183cd3
 # ╠═1f903163-f9f1-4d11-a57f-d67c88970d1c
 # ╠═6f71127e-a15c-4ec9-a6b7-d7016d52e390
+# ╠═2a48c478-9906-4e4b-9487-03f80459ac9d

--- a/test/notebooks/source_types.jl
+++ b/test/notebooks/source_types.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.22
+# v0.20.13
 
 using Markdown
 using InteractiveUtils
@@ -10,6 +10,11 @@ import Pkg
 # ╔═╡ 89e763c1-1a08-4b40-9fbf-b03b400ead5d
 # avoid julia version clashes during testing
 Pkg.activate(Base.current_project())
+
+# ╔═╡ 8ff0322b-f912-4e41-9650-9ba0e56b1331
+md"""
+## Point structure
+"""
 
 # ╔═╡ 8c9967cf-9e6d-47c9-b7fd-558c78246562
 abstract type AbstractPoint end
@@ -26,10 +31,38 @@ a = Point(1, 2)
 # ╔═╡ c8e6ea08-4018-4ab4-bc1a-1126e5fa4e28
 b = 2a.x
 
+# ╔═╡ 7e0eb7d8-235c-4780-83b7-87ead99d26e4
+md"""
+## Parametric type assignments
+"""
+
+# ╔═╡ 197051cf-d9aa-481a-aba1-f8db31730f2d
+# cf. https://github.com/fonsp/Pluto.jl/pull/521
+Nullable{T} = Union{T, Nothing}
+
+# ╔═╡ c9acd677-b8a0-401f-8cf4-c91873d2d045
+fun_1(x::Nullable{Float64}) = isnothing(x) ? NaN : x^2
+
+# ╔═╡ c59a7988-5a9a-47b8-b162-41503a56a2c5
+x_1 = 2.0
+
+# ╔═╡ 43479f3a-a3c9-4080-92ee-3f608aa0e300
+res_1_nothing = fun_1(nothing)
+
+# ╔═╡ 9bf33e28-a75e-41a6-af35-fcb927945079
+res_1_2 = fun_1(x_1)
+
 # ╔═╡ Cell order:
 # ╠═a9d0dc94-7c75-431a-b25d-7d89d2a3a9be
 # ╠═89e763c1-1a08-4b40-9fbf-b03b400ead5d
+# ╠═8ff0322b-f912-4e41-9650-9ba0e56b1331
 # ╠═8c9967cf-9e6d-47c9-b7fd-558c78246562
 # ╠═51d30d68-ec90-4df7-9542-88066d689e80
 # ╠═ddaac278-e77d-4347-bff0-8ae4f8bc1cb8
 # ╠═c8e6ea08-4018-4ab4-bc1a-1126e5fa4e28
+# ╠═7e0eb7d8-235c-4780-83b7-87ead99d26e4
+# ╠═197051cf-d9aa-481a-aba1-f8db31730f2d
+# ╠═c9acd677-b8a0-401f-8cf4-c91873d2d045
+# ╠═c59a7988-5a9a-47b8-b162-41503a56a2c5
+# ╠═43479f3a-a3c9-4080-92ee-3f608aa0e300
+# ╠═9bf33e28-a75e-41a6-af35-fcb927945079


### PR DESCRIPTION
Restores optimal speed.
In passing, also test `Nullable{T} = Union{T, Nothing}`,
cf. https://github.com/fonsp/Pluto.jl/pull/521.

The benchmark file has a lot of code duplication with the tests; it's temporary.