### PR TITLE
Separate topology and function modules

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoExtractors"
 uuid = "25cc9095-8c7a-4c84-8905-c5de52e7766c"
 authors = ["ederag <edera@gmx.fr> and contributors"]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/test/notebooks/extract_from_source_usings.jl
+++ b/test/notebooks/extract_from_source_usings.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.20.8
+# v0.20.13
 
 using Markdown
 using InteractiveUtils
@@ -85,6 +85,25 @@ expected_v1_v2_out_d_indirect = dot(v1, v2)
 # ╔═╡ 03542919-9804-485d-9be1-418ad3e88ac3
 PlutoTest.@test fun_v1_v2_out_d_indirect(v1, v2) == expected_v1_v2_out_d_indirect
 
+# ╔═╡ cc1cfa88-90d7-4445-8064-bf4b71456d4d
+md"""
+## Soft definitions
+"""
+
+# ╔═╡ 32721171-d229-46b8-89ce-c737adc352af
+@nb_extract(
+	utp,
+	function fun_options_dict(option_a, option_b)
+		return options_dict
+	end
+)
+
+# ╔═╡ 1c34c068-4572-4e8c-be97-b5ba00030af1
+options_dict = fun_options_dict(2.0, 3.0)
+
+# ╔═╡ e024bab4-0bf9-4bb2-8128-70e7b534c1da
+PlutoTest.@test options_dict[:a] == 2.0 && options_dict[:b] == 3.0
+
 # ╔═╡ Cell order:
 # ╠═51df9d39-7d35-49e1-bac3-7354882bb141
 # ╠═67aa154f-a294-41ce-aea5-36cf5ddcf1de
@@ -107,3 +126,7 @@ PlutoTest.@test fun_v1_v2_out_d_indirect(v1, v2) == expected_v1_v2_out_d_indirec
 # ╠═24f70698-dd49-49e4-822b-92f6dfe2d026
 # ╠═83f08626-cd31-45b1-8b4e-dba7c40e4bf2
 # ╠═03542919-9804-485d-9be1-418ad3e88ac3
+# ╠═cc1cfa88-90d7-4445-8064-bf4b71456d4d
+# ╠═32721171-d229-46b8-89ce-c737adc352af
+# ╠═1c34c068-4572-4e8c-be97-b5ba00030af1
+# ╠═e024bab4-0bf9-4bb2-8128-70e7b534c1da

--- a/test/notebooks/full_topology.jl
+++ b/test/notebooks/full_topology.jl
@@ -1,0 +1,70 @@
+### A Pluto.jl notebook ###
+# v0.20.13
+
+using Markdown
+using InteractiveUtils
+
+# ╔═╡ 51df9d39-7d35-49e1-bac3-7354882bb141
+import Pkg
+
+# ╔═╡ 67aa154f-a294-41ce-aea5-36cf5ddcf1de
+# ╠═╡ skip_as_script = true
+#=╠═╡
+Pkg.activate(Base.current_project())
+  ╠═╡ =#
+
+# ╔═╡ 640d5a61-0e23-4614-96d7-6d79e015eee3
+using PlutoExtractors
+
+# ╔═╡ 9f58ade4-c81b-45fb-a497-4f7503b94e13
+import PlutoTest
+
+# ╔═╡ 88334e90-1486-40e2-84d5-8f49eda045fe
+root_dir = pkgdir(PlutoExtractors)
+
+# ╔═╡ d5a36c7c-95bf-4bd3-96d7-1b2392eeec94
+source_nb_file = joinpath(root_dir, "test", "notebooks", "source_usings.jl")
+
+# ╔═╡ 8411b188-54d9-43fd-9d47-6bd6d7f5ed86
+md"""
+# Tests
+"""
+
+# ╔═╡ cc1cfa88-90d7-4445-8064-bf4b71456d4d
+md"""
+## Soft definitions
+"""
+
+# ╔═╡ 51a23f6a-f327-4fbe-a722-37b4bb9fe4b7
+# We want the full topology to be complete
+# even when Parameters is not used in the calling notebook
+PlutoTest.@test !@isdefined Parameters
+
+# ╔═╡ 987fd80c-a884-4828-8c5d-96c92d5f099a
+utp = PlutoExtractors.@load_full_topology(source_nb_file)
+
+# ╔═╡ efc5cf0b-20ff-4f1c-a99e-d9280959dba1
+cell = filter(utp.cell_order) do cell
+	startswith(cell.code, "using Parameters")
+end |> only
+
+# ╔═╡ 08c48966-25ff-43b6-a628-39e6ff6971dd
+node = utp.nodes[cell]
+
+# ╔═╡ 66bfc7d3-035f-46cf-bcfe-fe12e45a31a1
+PlutoTest.@test !isempty(node.soft_definitions)
+
+# ╔═╡ Cell order:
+# ╠═51df9d39-7d35-49e1-bac3-7354882bb141
+# ╠═67aa154f-a294-41ce-aea5-36cf5ddcf1de
+# ╠═640d5a61-0e23-4614-96d7-6d79e015eee3
+# ╠═9f58ade4-c81b-45fb-a497-4f7503b94e13
+# ╠═88334e90-1486-40e2-84d5-8f49eda045fe
+# ╠═d5a36c7c-95bf-4bd3-96d7-1b2392eeec94
+# ╠═8411b188-54d9-43fd-9d47-6bd6d7f5ed86
+# ╠═cc1cfa88-90d7-4445-8064-bf4b71456d4d
+# ╠═51a23f6a-f327-4fbe-a722-37b4bb9fe4b7
+# ╠═987fd80c-a884-4828-8c5d-96c92d5f099a
+# ╠═efc5cf0b-20ff-4f1c-a99e-d9280959dba1
+# ╠═08c48966-25ff-43b6-a628-39e6ff6971dd
+# ╠═66bfc7d3-035f-46cf-bcfe-fe12e45a31a1

--- a/test/notebooks/helpers.jl
+++ b/test/notebooks/helpers.jl
@@ -89,7 +89,7 @@ expected_fun_wrapper_expr = PlutoExtractors.rm_all_lines(
 PlutoTest.@test fun_wrapper_expr == expected_fun_wrapper_expr
 
 # ╔═╡ 94b0b7e1-0a51-4cbd-92a1-ca8db5721312
-header_expr = PlutoExtractors.collect_header_expressions(utp, [])
+header_expr = PlutoExtractors.collect_header_expressions(utp)
 
 # ╔═╡ fb850d61-5795-4424-bcd2-7ae811d98c92
 tpo = PDE.topological_order(utp)

--- a/test/notebooks/source_usings.jl
+++ b/test/notebooks/source_usings.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.22
+# v0.20.13
 
 using Markdown
 using InteractiveUtils
@@ -13,6 +13,9 @@ Pkg.activate(Base.current_project())
 
 # ╔═╡ d76267bc-917e-42a0-8576-33a0a84ad8e3
 using LinearAlgebra:dot
+
+# ╔═╡ cadd5316-6ab0-44af-ac47-db0827059247
+using Parameters  # exports type2dict (so to Pluto this is a soft definition)
 
 # ╔═╡ 56bc6498-f5f2-11ec-0723-e94eb89c7289
 v1 = [0, 1, 2]
@@ -29,6 +32,24 @@ d_fun(x, y) = dot(x, y)
 # ╔═╡ f5a959b0-372f-400c-ba67-31460ceb6447
 d_indirect = d_fun(v1, v2)
 
+# ╔═╡ 562d4f72-d91a-4b3a-8afc-3169aad665b3
+struct Options{F}
+	a::F
+	b::F
+end
+
+# ╔═╡ 0d074e32-08af-41da-aa4d-e5bc9992c2ff
+option_a = 1.0
+
+# ╔═╡ 9d95d185-6220-4eb3-ade7-0bab44045031
+option_b = 2.0
+
+# ╔═╡ 46c4c752-927f-4251-905c-1c3fb7348fb6
+options_struct = Options(option_a, option_b)
+
+# ╔═╡ 65605220-5ea2-4e1d-82c5-e9d7a2677e19
+options_dict = type2dict(options_struct)
+
 # ╔═╡ Cell order:
 # ╠═52a54f2e-33f7-45f0-b251-59c476c17994
 # ╠═a1be466e-5d31-4024-8c05-6afd5ede7840
@@ -38,3 +59,9 @@ d_indirect = d_fun(v1, v2)
 # ╠═98b0c017-9e5f-40b7-873a-a1067cb66031
 # ╠═bb19b3d0-ad7d-4220-a117-fd6f60b0f2bc
 # ╠═f5a959b0-372f-400c-ba67-31460ceb6447
+# ╠═cadd5316-6ab0-44af-ac47-db0827059247
+# ╠═562d4f72-d91a-4b3a-8afc-3169aad665b3
+# ╠═0d074e32-08af-41da-aa4d-e5bc9992c2ff
+# ╠═9d95d185-6220-4eb3-ade7-0bab44045031
+# ╠═46c4c752-927f-4251-905c-1c3fb7348fb6
+# ╠═65605220-5ea2-4e1d-82c5-e9d7a2677e19

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,10 @@ server_session.connected_clients[fakeclient.id] = fakeclient
 		include("notebooks/helpers.jl")
 	end
 
+	@testset "Full topology" begin
+		include("notebooks/full_topology.jl")
+	end
+
 	@testset "Extract from source_basic.jl" begin
 		include("notebooks/extract_from_source_basic.jl")
 	end


### PR DESCRIPTION
Create separate modules for the topology and the function.
The topology needs all the packages using/import statements for macro-expansion to succeed,
irrespective of cell disabling.
Whereas the function might need a subset of these
(and at some point maybe the cell disabling should be taken into account).

This PR just prepares for this (the two modules headers are identical for now).
In principle this is non-breaking.