### PR TITLE
Simplify API (no intermediate topology, just the source notebook path)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoExtractors"
 uuid = "25cc9095-8c7a-4c84-8905-c5de52e7766c"
 authors = ["ederag <edera@gmx.fr> and contributors"]
-version = "0.2.3"
+version = "0.3.0"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/src/notebooks/extractors.jl
+++ b/src/notebooks/extractors.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.20.13
+# v0.20.17
 
 #> [frontmatter]
 #> title = ""
@@ -220,7 +220,7 @@ julia> fun(2)
 
 See also [`load_updated_topology`](@ref)
 """
-macro nb_extract(utp, template)
+macro nb_extract(source_path, template)
 	# A module where all the packages are accessible
 	# for the macroexpansion phase (to determine dependencies),
 	# that will hold a more complete topology
@@ -245,12 +245,13 @@ macro nb_extract(utp, template)
 	# => Just prepare the expressions to be evaluated when the macro is executed.
 	return quote
 		let
+			basic_utp = load_updated_topology($(esc(source_path)))
 			# utp is not complete yet, but enough to gather the module header
 			# Note: @load_full_topology can't be used here
 			# (might not be defined in the caller scope)
 			topology_module_expr = get_topology_module_expr(
 				$(QuoteNode(topology_module_sym)),
-				$(esc(utp))
+				basic_utp
 			)
 			tpm = $__module__.eval(topology_module_expr)
 

--- a/test/live.jl
+++ b/test/live.jl
@@ -2,14 +2,13 @@
 # where server_session is defined
 
 @testset "Basic" begin
-	source_basic_path = pkgdir(PlutoExtractors, "test", "notebooks", "source_basic.jl")
+	source_path = pkgdir(PlutoExtractors, "test", "notebooks", "source_basic.jl")
 
 	# "# expected" cells produce an output that the next cell should reproduce
 	dest_notebook = Pluto.Notebook([
 		Pluto.Cell("""using PlutoExtractors"""),
-		Pluto.Cell("""utp = load_updated_topology("$(source_basic_path)")"""),
 		Pluto.Cell("""
-			@nb_extract(utp, 
+			@nb_extract("$(source_path)", 
 				function fun(a)
 					return c
 				end
@@ -27,6 +26,6 @@
 	cell(idx) = dest_notebook.cells[idx]
 	@test cell(1) |> noerror
 	@test cell(2) |> noerror
-	@test cell(3) |> noerror
-	@test cell(5).output.body == cell(4).output.body
+	#@test cell(3) |> noerror
+	@test cell(4).output.body == cell(3).output.body
 end

--- a/test/notebooks/extract_from_extract_from_source_basic.jl
+++ b/test/notebooks/extract_from_extract_from_source_basic.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.22
+# v0.20.17
 
 using Markdown
 using InteractiveUtils
@@ -26,7 +26,7 @@ import PlutoTest
 root_dir = pkgdir(PlutoExtractors)
 
 # ╔═╡ 35bab28c-477c-43dd-b339-13cfdbf2f33e
-source_nb_file = joinpath(root_dir, "test", "notebooks", "extract_from_source_basic.jl")
+source_path = joinpath(root_dir, "test", "notebooks", "extract_from_source_basic.jl")
 
 # ╔═╡ 89dd6ff4-2495-4bd1-96ef-8962f8041cf3
 md"""
@@ -36,12 +36,9 @@ md"""
 # ╔═╡ 214a48ea-1769-45c8-b113-bb17a1a766b7
 md"## Just one variable"
 
-# ╔═╡ b9e09fd4-f34a-4c72-b979-09bb1b1b57e7
-nb = load_nb_with_topology(source_nb_file)
-
 # ╔═╡ a8ac792a-d83b-48ea-a98b-79c43ef76c2e
 @nb_extract(
-	nb,
+	source_path,
 	function get_fun1_a()
 		return fun1_a
 	end
@@ -66,7 +63,6 @@ PlutoTest.@test fun1_a == 1
 # ╠═35bab28c-477c-43dd-b339-13cfdbf2f33e
 # ╟─89dd6ff4-2495-4bd1-96ef-8962f8041cf3
 # ╟─214a48ea-1769-45c8-b113-bb17a1a766b7
-# ╠═b9e09fd4-f34a-4c72-b979-09bb1b1b57e7
 # ╠═a8ac792a-d83b-48ea-a98b-79c43ef76c2e
 # ╠═f49f8d22-2b0b-4884-b9be-368dd297fb34
 # ╠═b2b5d93a-faff-4d9f-92da-40bf95efcff6

--- a/test/notebooks/extract_from_source_basic.jl
+++ b/test/notebooks/extract_from_source_basic.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.20.8
+# v0.20.17
 
 using Markdown
 using InteractiveUtils
@@ -26,7 +26,7 @@ import PlutoTest
 root_dir = pkgdir(PlutoExtractors)
 
 # ╔═╡ 35bab28c-477c-43dd-b339-13cfdbf2f33e
-source_nb_file = joinpath(root_dir, "test", "notebooks", "source_basic.jl")
+source_path = joinpath(root_dir, "test", "notebooks", "source_basic.jl")
 
 # ╔═╡ 89dd6ff4-2495-4bd1-96ef-8962f8041cf3
 md"""
@@ -36,12 +36,9 @@ md"""
 # ╔═╡ 214a48ea-1769-45c8-b113-bb17a1a766b7
 md"## Just one variable"
 
-# ╔═╡ b9e09fd4-f34a-4c72-b979-09bb1b1b57e7
-utp = load_updated_topology(source_nb_file)
-
 # ╔═╡ a8ac792a-d83b-48ea-a98b-79c43ef76c2e
 @nb_extract(
-	utp,
+	source_path,
 	function fun1()
 		return a
 	end
@@ -60,7 +57,7 @@ md"""
 
 # ╔═╡ aada1eb9-5887-4c4f-a796-45217ff8ece7
 @nb_extract(
-	utp,
+	source_path,
 	function fun_out_nt_a_c()
 		return (; a = a, c = c)
 	end
@@ -79,7 +76,7 @@ md"""
 
 # ╔═╡ abfcb9bd-8c20-47a9-9f1c-12e75426d6df
 @nb_extract(
-	utp,
+	source_path,
 	function fun_a_out_nt_b_c(a)
 		return (; b = b, c = c)
 	end
@@ -98,7 +95,7 @@ md"""
 
 # ╔═╡ 66929e56-fb7f-49fe-a0ce-b4a58b558b37
 @nb_extract(
-	utp,
+	source_path,
 	function fun_6(; a=2)
 		return c
 	end
@@ -118,7 +115,7 @@ md"""
 # ╔═╡ 02e44c02-d427-4646-afdc-b52f1e5a9595
 res_inner = let
 	@nb_extract(
-		utp,
+		source_path,
 		function inner_fun(a)
 			return c
 		end
@@ -139,7 +136,7 @@ md"""
 
 # ╔═╡ 484fb80e-2722-42b9-bb39-6f2cade9b076
 @nb_extract(
-	utp,
+	source_path,
 	function fun_5(a::Int)
 		return c
 	end
@@ -158,7 +155,7 @@ md"""
 
 # ╔═╡ 4366181c-9516-436e-8072-31488d4722ab
 @nb_extract(
-	utp,
+	source_path,
 	function fun_error_1()
 		return non_existing  # :non_existing is not defined in nb
 	end
@@ -176,7 +173,6 @@ PlutoTest.@test_throws UndefVarError(:non_existing) fun_error_1()
 # ╠═35bab28c-477c-43dd-b339-13cfdbf2f33e
 # ╟─89dd6ff4-2495-4bd1-96ef-8962f8041cf3
 # ╟─214a48ea-1769-45c8-b113-bb17a1a766b7
-# ╠═b9e09fd4-f34a-4c72-b979-09bb1b1b57e7
 # ╠═a8ac792a-d83b-48ea-a98b-79c43ef76c2e
 # ╠═b2b5d93a-faff-4d9f-92da-40bf95efcff6
 # ╠═4c009a24-8098-4803-9396-43598e2c382d

--- a/test/notebooks/extract_from_source_bind.jl
+++ b/test/notebooks/extract_from_source_bind.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.20.8
+# v0.20.17
 
 using Markdown
 using InteractiveUtils
@@ -38,7 +38,7 @@ import PlutoTest
 root_dir = pkgdir(PlutoExtractors)
 
 # ╔═╡ 35bab28c-477c-43dd-b339-13cfdbf2f33e
-source_nb_file = joinpath(root_dir, "test", "notebooks", "source_bind.jl")
+source_path = joinpath(root_dir, "test", "notebooks", "source_bind.jl")
 
 # ╔═╡ 89dd6ff4-2495-4bd1-96ef-8962f8041cf3
 md"""
@@ -52,9 +52,6 @@ md"""
 Pluto treats @bind special
 """
 
-# ╔═╡ b9e09fd4-f34a-4c72-b979-09bb1b1b57e7
-utp = load_updated_topology(source_nb_file)
-
 # ╔═╡ 1edaab0a-c3f1-45d0-9be7-ceee605e1a1c
 md"""
 ### Variable needed and not given
@@ -62,7 +59,7 @@ md"""
 
 # ╔═╡ a8ac792a-d83b-48ea-a98b-79c43ef76c2e
 PlutoTest.@test_throws ["Please add `a` to the given arguments"] @nb_extract(
-	utp,
+	source_path,
 	function fun1()
 		return b
 	end
@@ -75,7 +72,7 @@ md"""
 
 # ╔═╡ c23487ba-d2e9-4665-b57f-d661b2d16a25
 @nb_extract(
-	utp,
+	source_path,
 	function fun2(a)
 		return b
 	end
@@ -95,7 +92,7 @@ md"""
 
 # ╔═╡ 193ebf2a-d2d3-4265-890f-6e808a88b907
 @nb_extract(
-	utp,
+	source_path,
 	function fun3()
 		return d
 	end
@@ -112,7 +109,7 @@ aptly error with a meaningful message.
 
 # ╔═╡ 0882779d-e882-4350-a714-49a9558c762c
 PlutoTest.@test_throws ["Please add `xe` to the given arguments"] @nb_extract(
-	utp,
+	source_path,
 	function fun4()
 		return xe
 	end
@@ -127,7 +124,6 @@ PlutoTest.@test_throws ["Please add `xe` to the given arguments"] @nb_extract(
 # ╠═35bab28c-477c-43dd-b339-13cfdbf2f33e
 # ╟─89dd6ff4-2495-4bd1-96ef-8962f8041cf3
 # ╟─214a48ea-1769-45c8-b113-bb17a1a766b7
-# ╠═b9e09fd4-f34a-4c72-b979-09bb1b1b57e7
 # ╟─1edaab0a-c3f1-45d0-9be7-ceee605e1a1c
 # ╠═a8ac792a-d83b-48ea-a98b-79c43ef76c2e
 # ╟─43f28cb1-ac86-49c0-8f9b-87e7cbc1287c

--- a/test/notebooks/extract_from_source_callables.jl
+++ b/test/notebooks/extract_from_source_callables.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.20.8
+# v0.20.17
 
 using Markdown
 using InteractiveUtils
@@ -26,10 +26,7 @@ import PlutoTest
 root_dir = pkgdir(PlutoExtractors)
 
 # ╔═╡ d5a36c7c-95bf-4bd3-96d7-1b2392eeec94
-source_nb_file = joinpath(root_dir, "test", "notebooks", "source_callables.jl")
-
-# ╔═╡ f3ee4c34-3c96-4254-aa07-34d67efaedc3
-utp = load_updated_topology(source_nb_file)
+source_path = joinpath(root_dir, "test", "notebooks", "source_callables.jl")
 
 # ╔═╡ 8411b188-54d9-43fd-9d47-6bd6d7f5ed86
 md"""
@@ -43,7 +40,7 @@ md"""
 
 # ╔═╡ 525f5fcc-efd1-48ef-8aeb-9c184e54a50d
 @nb_extract(
-	utp,
+	source_path,
 	function fun_1(x)
 		return scaled_x
 	end
@@ -59,7 +56,7 @@ md"""
 
 # ╔═╡ 79059923-0737-40fb-80d9-5381bdece98a
 @nb_extract(
-	utp,
+	source_path,
 	function fun_2(x)
 		return scaled_x_2
 	end
@@ -75,7 +72,7 @@ md"""
 
 # ╔═╡ ace85006-e9c4-43c3-a004-6f2b818afd49
 @nb_extract(
-	utp,
+	source_path,
 	function fun_3(x)
 		return fun_fun_long(x)
 	end
@@ -86,7 +83,7 @@ PlutoTest.@test fun_3(3) == 27
 
 # ╔═╡ 74986ddb-f85a-477b-b036-6a534ea65e56
 @nb_extract(
-	utp,
+	source_path,
 	function fun_4()
 		return d
 	end
@@ -97,7 +94,7 @@ PlutoTest.@test fun_4() == 64
 
 # ╔═╡ f255eb1a-9fc1-4dfa-812e-faaaa42ed666
 @nb_extract(
-	utp,
+	source_path,
 	function fun_5()
 		return fun_capt_a()
 	end
@@ -108,7 +105,7 @@ PlutoTest.@test fun_5() == 2
 
 # ╔═╡ 91f52bb6-036e-472f-98d5-8e5dedd236e6
 @nb_extract(
-	utp,
+	source_path,
 	function fun_6(a)
 		return fun_capt_a()
 	end
@@ -119,7 +116,7 @@ PlutoTest.@test fun_6(3) == 3
 
 # ╔═╡ 52cd299d-7e5c-4342-aedb-81a55a5253b1
 @nb_extract(
-	utp,
+	source_path,
 	function fun_7(b)
 		return fun_capt_a_b()
 	end
@@ -130,7 +127,7 @@ PlutoTest.@test fun_7(3) == 5
 
 # ╔═╡ 2386b27f-1c20-4884-9898-2acd57205e54
 @nb_extract(
-	utp,
+	source_path,
 	function fun_8(a)
 		return fun_chain()
 	end
@@ -146,7 +143,6 @@ fun_8(2)
 # ╠═9f58ade4-c81b-45fb-a497-4f7503b94e13
 # ╠═88334e90-1486-40e2-84d5-8f49eda045fe
 # ╠═d5a36c7c-95bf-4bd3-96d7-1b2392eeec94
-# ╠═f3ee4c34-3c96-4254-aa07-34d67efaedc3
 # ╠═8411b188-54d9-43fd-9d47-6bd6d7f5ed86
 # ╠═e4837658-a2ef-4dfa-8cb0-f909eac426b6
 # ╠═525f5fcc-efd1-48ef-8aeb-9c184e54a50d

--- a/test/notebooks/extract_from_source_consts.jl
+++ b/test/notebooks/extract_from_source_consts.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.20.8
+# v0.20.17
 
 using Markdown
 using InteractiveUtils
@@ -26,7 +26,7 @@ import PlutoTest
 root_dir = pkgdir(PlutoExtractors)
 
 # ╔═╡ 818ce446-5aaf-4b71-8068-bf26b86a61f9
-source_nb_file = joinpath(root_dir, "test", "notebooks", "source_consts.jl")
+source_path = joinpath(root_dir, "test", "notebooks", "source_consts.jl")
 
 # ╔═╡ 6cd98e90-6332-4fad-b57c-3868a4ce7479
 md"""
@@ -36,12 +36,9 @@ md"""
 # ╔═╡ 77e340fc-40d7-48d6-b220-da20dac99572
 md"## Just one variable"
 
-# ╔═╡ a946286a-cef8-49e3-a98c-f87721f3d80d
-utp = load_updated_topology(source_nb_file)
-
 # ╔═╡ f064422c-b72a-4450-844f-4cb7172bd753
 @nb_extract(
-	utp,
+	source_path,
 	function fun_out_a()
 		return a
 	end
@@ -62,7 +59,6 @@ PlutoTest.@test fun_out_a() == 1
 # ╠═818ce446-5aaf-4b71-8068-bf26b86a61f9
 # ╠═6cd98e90-6332-4fad-b57c-3868a4ce7479
 # ╠═77e340fc-40d7-48d6-b220-da20dac99572
-# ╠═a946286a-cef8-49e3-a98c-f87721f3d80d
 # ╠═f064422c-b72a-4450-844f-4cb7172bd753
 # ╠═37043d8c-e840-4043-8375-dc1083f5aa89
 # ╠═295c54c2-7697-43cb-a474-634ff6523a60

--- a/test/notebooks/extract_from_source_markdown.jl
+++ b/test/notebooks/extract_from_source_markdown.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.20.8
+# v0.20.17
 
 using Markdown
 using InteractiveUtils
@@ -26,7 +26,7 @@ import PlutoTest
 root_dir = pkgdir(PlutoExtractors)
 
 # ╔═╡ 35bab28c-477c-43dd-b339-13cfdbf2f33e
-source_nb_file = joinpath(root_dir, "test", "notebooks", "source_markdown.jl")
+source_path = joinpath(root_dir, "test", "notebooks", "source_markdown.jl")
 
 # ╔═╡ 89dd6ff4-2495-4bd1-96ef-8962f8041cf3
 md"""
@@ -36,12 +36,9 @@ md"""
 # ╔═╡ 214a48ea-1769-45c8-b113-bb17a1a766b7
 md"## Just one variable"
 
-# ╔═╡ b9e09fd4-f34a-4c72-b979-09bb1b1b57e7
-utp = load_updated_topology(source_nb_file)
-
 # ╔═╡ a8ac792a-d83b-48ea-a98b-79c43ef76c2e
 @nb_extract(
-	utp,
+	source_path,
 	function fun1()
 		return b
 	end
@@ -62,7 +59,6 @@ PlutoTest.@test fun1_b == 2
 # ╠═35bab28c-477c-43dd-b339-13cfdbf2f33e
 # ╟─89dd6ff4-2495-4bd1-96ef-8962f8041cf3
 # ╟─214a48ea-1769-45c8-b113-bb17a1a766b7
-# ╠═b9e09fd4-f34a-4c72-b979-09bb1b1b57e7
 # ╠═a8ac792a-d83b-48ea-a98b-79c43ef76c2e
 # ╠═b2b5d93a-faff-4d9f-92da-40bf95efcff6
 # ╠═84f703bd-39d4-43a0-8062-34decd68c6bc

--- a/test/notebooks/extract_from_source_semicolon.jl
+++ b/test/notebooks/extract_from_source_semicolon.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.20.8
+# v0.20.17
 
 using Markdown
 using InteractiveUtils
@@ -32,7 +32,7 @@ EEE = PDE.ExpressionExplorerExtras
 root_dir = pkgdir(PlutoExtractors)
 
 # ╔═╡ 35bab28c-477c-43dd-b339-13cfdbf2f33e
-source_nb_file = joinpath(root_dir, "test", "notebooks", "source_semicolon.jl")
+source_path = joinpath(root_dir, "test", "notebooks", "source_semicolon.jl")
 
 # ╔═╡ 89dd6ff4-2495-4bd1-96ef-8962f8041cf3
 md"""
@@ -43,11 +43,11 @@ md"""
 md"## Just one variable"
 
 # ╔═╡ b9e09fd4-f34a-4c72-b979-09bb1b1b57e7
-utp = load_updated_topology(source_nb_file)
+utp = load_updated_topology(source_path)
 
 # ╔═╡ a8ac792a-d83b-48ea-a98b-79c43ef76c2e
 @nb_extract(
-	utp,
+	source_path,
 	function fun1()
 		return b
 	end
@@ -86,8 +86,23 @@ b_code = utp.codes[b_cell]
 # ╔═╡ af63b9bf-9deb-43c9-b9ae-65a74e7fe8e7
 EEE.pretransform_pluto(b_code.parsedcode)
 
+# ╔═╡ c8f43541-6a3d-4980-a6bd-0fef63041fca
+template = :(
+	function fun1()
+		return b
+	end
+)
+
+# ╔═╡ ac91075f-0a6c-4eae-9a95-e33795e6696d
+(template_dict, given_symbols, needed_symbols) = PlutoExtractors.template_analysis(template)
+
 # ╔═╡ 1d54eab5-af3a-400d-90d8-97be0cffe35b
-PlutoExtractors.nb_extractor_core(utp, given=[], outputs=[:b])
+PlutoExtractors.nb_extractor_core(
+	utp,
+	template_dict,
+	given_symbols,
+	needed_symbols
+)
 
 # ╔═╡ Cell order:
 # ╠═64f6372a-eff1-11ec-2395-31d68eda5f3a
@@ -111,4 +126,6 @@ PlutoExtractors.nb_extractor_core(utp, given=[], outputs=[:b])
 # ╠═d118c09b-d70f-4f24-be30-122a3c18abd6
 # ╠═30f9606c-134c-4717-82d4-9b6b031116bb
 # ╠═af63b9bf-9deb-43c9-b9ae-65a74e7fe8e7
+# ╠═c8f43541-6a3d-4980-a6bd-0fef63041fca
+# ╠═ac91075f-0a6c-4eae-9a95-e33795e6696d
 # ╠═1d54eab5-af3a-400d-90d8-97be0cffe35b

--- a/test/notebooks/extract_from_source_types.jl
+++ b/test/notebooks/extract_from_source_types.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.20.13
+# v0.20.17
 
 using Markdown
 using InteractiveUtils
@@ -26,7 +26,7 @@ import PlutoTest
 root_dir = pkgdir(PlutoExtractors)
 
 # ╔═╡ d5a36c7c-95bf-4bd3-96d7-1b2392eeec94
-source_nb_file = joinpath(root_dir, "test", "notebooks", "source_types.jl")
+source_path = joinpath(root_dir, "test", "notebooks", "source_types.jl")
 
 # ╔═╡ 8411b188-54d9-43fd-9d47-6bd6d7f5ed86
 md"""
@@ -37,9 +37,6 @@ md"""
 md"## Types
 "
 
-# ╔═╡ f3ee4c34-3c96-4254-aa07-34d67efaedc3
-utp = load_updated_topology(source_nb_file)
-
 # ╔═╡ e4837658-a2ef-4dfa-8cb0-f909eac426b6
 md"""
 ### Tests
@@ -47,7 +44,7 @@ md"""
 
 # ╔═╡ 525f5fcc-efd1-48ef-8aeb-9c184e54a50d
 @nb_extract(
-	utp,
+	source_path,
 	function fun_1()
 		return b
 	end
@@ -69,7 +66,7 @@ Sensitive to [Julia#50354](https://github.com/JuliaLang/julia/issues/50354) ?
 # ╔═╡ 919bd4ba-6fe2-4641-b7b7-1c184f97679d
 #  Can't get the module yet, so test inside the function
 @nb_extract(
-	utp,
+	source_path,
 	function fun_2()
 		sup_match = supertype(Point) === AbstractPoint
 		return sup_match
@@ -86,7 +83,7 @@ md"""
 
 # ╔═╡ f87071f9-f1a1-4801-9c38-6f2ccba20e1c
 @nb_extract(
-	utp,
+	source_path,
 	function fun_3(x_1)
 		return res_1_2
 	end
@@ -107,7 +104,6 @@ PlutoTest.@test isnan(fun_3(nothing))
 # ╠═d5a36c7c-95bf-4bd3-96d7-1b2392eeec94
 # ╠═8411b188-54d9-43fd-9d47-6bd6d7f5ed86
 # ╠═53c808e9-a4bc-4fbc-b186-41532f54e7f8
-# ╠═f3ee4c34-3c96-4254-aa07-34d67efaedc3
 # ╠═e4837658-a2ef-4dfa-8cb0-f909eac426b6
 # ╠═525f5fcc-efd1-48ef-8aeb-9c184e54a50d
 # ╠═b8879c23-6aec-435a-a875-e30ebd1b4d5a

--- a/test/notebooks/extract_from_source_unpack.jl
+++ b/test/notebooks/extract_from_source_unpack.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.20.8
+# v0.20.17
 
 using Markdown
 using InteractiveUtils
@@ -38,13 +38,7 @@ EEE = PDE.ExpressionExplorerExtras
 root_dir = pkgdir(PlutoExtractors)
 
 # ╔═╡ d5a36c7c-95bf-4bd3-96d7-1b2392eeec94
-source_nb_file = joinpath(root_dir, "test", "notebooks", "source_unpack.jl")
-
-# ╔═╡ f3ee4c34-3c96-4254-aa07-34d67efaedc3
-utp = load_updated_topology(source_nb_file)
-
-# ╔═╡ 155b072a-d32f-4062-ad4e-1ab9792614ae
-typeof(utp.codes)
+source_path = joinpath(root_dir, "test", "notebooks", "source_unpack.jl")
 
 # ╔═╡ 8411b188-54d9-43fd-9d47-6bd6d7f5ed86
 md"""
@@ -59,7 +53,7 @@ md"## Regular
 
 # ╔═╡ 21f86448-721a-4ffe-a098-1482071de585
 @nb_extract(
-	utp,
+	source_path,
 	function fun1()
 		return a, c
 	end
@@ -72,6 +66,12 @@ PlutoTest.@test fun1() == (1, 3)
 md"""
 ## Debug
 """
+
+# ╔═╡ f3ee4c34-3c96-4254-aa07-34d67efaedc3
+utp = load_updated_topology(source_path)
+
+# ╔═╡ 155b072a-d32f-4062-ad4e-1ab9792614ae
+typeof(utp.codes)
 
 # ╔═╡ d12b6a5b-1e35-42af-bf89-3959565464ae
 utp.unresolved_cells
@@ -106,13 +106,13 @@ EEE.pretransform_pluto(unpack_ac_code.parsedcode)
 # ╠═6fc87b31-9206-4ccc-87a6-ad37b0d25415
 # ╠═88334e90-1486-40e2-84d5-8f49eda045fe
 # ╠═d5a36c7c-95bf-4bd3-96d7-1b2392eeec94
-# ╠═f3ee4c34-3c96-4254-aa07-34d67efaedc3
-# ╠═155b072a-d32f-4062-ad4e-1ab9792614ae
 # ╠═8411b188-54d9-43fd-9d47-6bd6d7f5ed86
 # ╠═53c808e9-a4bc-4fbc-b186-41532f54e7f8
 # ╠═21f86448-721a-4ffe-a098-1482071de585
 # ╠═737782bb-ea44-41b4-b467-da42793fd616
 # ╠═d3341aee-be88-4f4c-a25b-7f2342a98591
+# ╠═f3ee4c34-3c96-4254-aa07-34d67efaedc3
+# ╠═155b072a-d32f-4062-ad4e-1ab9792614ae
 # ╠═d12b6a5b-1e35-42af-bf89-3959565464ae
 # ╠═198d4900-9ae1-456f-b1cf-3c26a2d8249a
 # ╠═1f19f8ec-46e5-48d7-a557-15db25bc12ff

--- a/test/notebooks/extract_from_source_usings.jl
+++ b/test/notebooks/extract_from_source_usings.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.20.13
+# v0.20.17
 
 using Markdown
 using InteractiveUtils
@@ -29,7 +29,7 @@ import PlutoTest
 root_dir = pkgdir(PlutoExtractors)
 
 # ╔═╡ d5a36c7c-95bf-4bd3-96d7-1b2392eeec94
-source_nb_file = joinpath(root_dir, "test", "notebooks", "source_usings.jl")
+source_path = joinpath(root_dir, "test", "notebooks", "source_usings.jl")
 
 # ╔═╡ 8411b188-54d9-43fd-9d47-6bd6d7f5ed86
 md"""
@@ -40,11 +40,11 @@ md"""
 md"## Just one variable"
 
 # ╔═╡ f3ee4c34-3c96-4254-aa07-34d67efaedc3
-utp = load_updated_topology(source_nb_file)
+# utp = load_updated_topology(source_path)
 
 # ╔═╡ 525f5fcc-efd1-48ef-8aeb-9c184e54a50d
 @nb_extract(
-	utp,
+	source_path,
 	function fun_out_d_direct()
 		return d_direct
 	end
@@ -64,7 +64,7 @@ md"## Indirect with two inputs"
 
 # ╔═╡ 75b6aae9-e013-4b6c-ac88-721e77822c97
 @nb_extract(
-	utp,
+	source_path,
 	function fun_v1_v2_out_d_indirect(v1, v2)
 		return d_indirect
 	end
@@ -92,7 +92,7 @@ md"""
 
 # ╔═╡ 32721171-d229-46b8-89ce-c737adc352af
 @nb_extract(
-	utp,
+	source_path,
 	function fun_options_dict(option_a, option_b)
 		return options_dict
 	end

--- a/test/notebooks/full_topology.jl
+++ b/test/notebooks/full_topology.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.20.13
+# v0.20.17
 
 using Markdown
 using InteractiveUtils
@@ -23,7 +23,7 @@ import PlutoTest
 root_dir = pkgdir(PlutoExtractors)
 
 # ╔═╡ d5a36c7c-95bf-4bd3-96d7-1b2392eeec94
-source_nb_file = joinpath(root_dir, "test", "notebooks", "source_usings.jl")
+source_path = joinpath(root_dir, "test", "notebooks", "source_usings.jl")
 
 # ╔═╡ 8411b188-54d9-43fd-9d47-6bd6d7f5ed86
 md"""
@@ -41,7 +41,7 @@ md"""
 PlutoTest.@test !@isdefined Parameters
 
 # ╔═╡ 987fd80c-a884-4828-8c5d-96c92d5f099a
-utp = PlutoExtractors.@load_full_topology(source_nb_file)
+utp = PlutoExtractors.@load_full_topology(source_path)
 
 # ╔═╡ efc5cf0b-20ff-4f1c-a99e-d9280959dba1
 cell = filter(utp.cell_order) do cell

--- a/test/notebooks/helpers.jl
+++ b/test/notebooks/helpers.jl
@@ -35,7 +35,7 @@ import PlutoDependencyExplorer as PDE
 root_dir = pkgdir(PlutoExtractors)
 
 # ╔═╡ d5a36c7c-95bf-4bd3-96d7-1b2392eeec94
-source_nb_file = joinpath(root_dir, "test", "notebooks", "source_types.jl")
+source_path = joinpath(root_dir, "test", "notebooks", "source_types.jl")
 
 # ╔═╡ 8411b188-54d9-43fd-9d47-6bd6d7f5ed86
 md"""
@@ -43,7 +43,7 @@ md"""
 """
 
 # ╔═╡ f3ee4c34-3c96-4254-aa07-34d67efaedc3
-utp = load_updated_topology(source_nb_file)
+utp = load_updated_topology(source_path)
 
 # ╔═╡ e7ea8a83-7b0f-4479-921d-fdc9ac80218a
 template = :(


### PR DESCRIPTION
The intermediate topology (`utp`) might be reintroduced at some point,
but in a different form (to be useful it should be more complete).
And it turned out that the time saved by sharing the topology creation was negligible
(for instance even a 700 lines .jl notebook takes less than 200 ms to extract)
So the API is now greatly simplified to
```julia-repl
julia> @nb_extract(
	source_path,
	...
)
```
In principle this is breaking, but to my knowledge no-one uses this package yet (which makes sense for an alpha stage);
please tell me otherwise (it might be possible to think of a non-breaking way) and use v0.2.3 in the meantime.
